### PR TITLE
Update and rename scripts/lazyload.js to 脚本/lazyload.js

### DIFF
--- a/脚本/lazyload.js
+++ b/脚本/lazyload.js
@@ -15,7 +15,7 @@ module.exports.lazyload = function (hexo) {
     });
   } else {
     hexo.extend.filter.register('after_render:html', function (str, data) {
-      return lazyProcess.call(this, str);
+      return lazyProcess.call(this, str, loadingImage);
     });
   }
 };


### PR DESCRIPTION
修复在`config.lazyload.onlypost`为false时，程序调用`lazyProcess(htmlContent, loadingImage)`为srcset属性赋值时出现`undefind`。
最后造成网站在最开始加载`loading.gif`时，出现404错误