### PR TITLE
菜单名添加多语言 日语

### DIFF
--- a/languages/ja.yml
+++ b/languages/ja.yml
@@ -1,0 +1,38 @@
+search:
+  title: 検索
+  keyword: キーワード
+  status:
+    success: v
+    error: x
+
+postTotal: 合計 %d 件のポスト
+
+paginator:
+  pre: 前のページ
+  next: 次のページ
+
+post:
+  toc: ディレクトリ
+
+home:
+  title: ホーム
+
+archive:
+  title: アーカイブ
+  subtitle: アーカイブ
+
+tag:
+  title: タグ
+  subtitle: タグ
+
+category:
+  title: カテゴリー
+  subtitle: カテゴリー
+
+about:
+  title: 本ブログ情報　
+  subtitle: 本ブログ情報
+
+page404:
+  title: ページが見つかりませんでした
+  subtitle: ページが見つかりませんでした


### PR DESCRIPTION
`About` 我翻译成了 `本ブログ情報`，意为`本博客的信息`。因为该主题用于`hexo博客`，而且`About`有"关于~"的意思。