### PR TITLE
modify link addr for categories and tags

### DIFF
--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -42,13 +42,13 @@ page.banner_img_height = theme.index.banner_img_height
         <% if(theme.index.post_meta.category && post.categories.length) { %>
           <i class="iconfont icon-inbox"></i>
           <% post.categories.each(function(cate){ %>
-            <a href="/categories/<%- encodeURI(cate.name.replace('.', '-')) %>"><%= cate.name %></a>&nbsp;
+            <a href="<%- url_for(cate.path) %>"><%= cate.name %></a>&nbsp;
           <% }) %>&nbsp;
         <% } %>
         <% if(theme.index.post_meta.tag && post.tags.length) { %>
           <i class="iconfont icon-tag"></i>
           <% post.tags.each(function(tag){ %>
-            <a href="/tags/<%- encodeURI(tag.name.replace('.', '-')) %>"><%= tag.name %></a>&nbsp;
+            <a href="<%- url_for(tag.path) %>"><%= tag.name %></a>&nbsp;
           <% }) %>
         <% } %>
       </div>

--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -22,7 +22,7 @@ page.banner_img_height = theme.post.banner_img_height
               <span>
                 <i class="iconfont icon-inbox"></i>
                 <% page.categories.each(function(cate) { %>
-                  <a class="hover-with-bg" href="/categories/<%- encodeURI(cate.name).replace('.', '-') %>"><%= cate.name %></a>
+                  <a class="hover-with-bg" href="<%- url_for(cate.path) %>"><%= cate.name %></a>
                   &nbsp;
                 <% }) %>
               </span>&nbsp;&nbsp;
@@ -31,7 +31,7 @@ page.banner_img_height = theme.post.banner_img_height
               <span>
                 <i class="iconfont icon-tag"></i>
                 <% page.tags.each(function(tag) { %>
-                  <a class="hover-with-bg" href="/tags/<%- encodeURI(tag.name).replace('.', '-') %>"><%= tag.name %></a>
+                  <a class="hover-with-bg" href="<%- url_for(tag.path) %>"><%= tag.name %></a>
                 <% }) %>
               </span>
             <% } %>


### PR DESCRIPTION
bugs fix for [issues149](https://github.com/fluid-dev/hexo-theme-fluid/issues/149)。当使用`category_map`和`tag_map`后，categories和tags的通过直接拼接得到的url不对，使用`url_for`函数来查找正确的url。