### PR TITLE
lazyload 匹配img正则修复

### DIFF
--- a/scripts/lazyload.js
+++ b/scripts/lazyload.js
@@ -21,10 +21,10 @@ module.exports.lazyload = function (hexo) {
 };
 
 function lazyProcess(htmlContent, loadingImage) {
-  return htmlContent.replace(/<img(\s*?)src="(.*?)"(.*?)>/gi, (str, p1, p2) => {
+  return htmlContent.replace(/<img[^>]+src="(.*?)"[^>]*>/gi, (str, p1) => {
     if (/srcset=/gi.test(str)) {
       return str;
     }
-    return str.replace(p2, `${p2}" srcset="${loadingImage}`);
+    return str.replace(p1, `${p1}" srcset="${loadingImage}`);
   });
 }


### PR DESCRIPTION
img tag 如果包含回行无法匹配，导致loading图片不显示