### PR TITLE
✨修复文章页图片显示问题

### DIFF
--- a/source/css/_pages/_about/about.styl
+++ b/source/css/_pages/_about/about.styl
@@ -4,7 +4,7 @@
   max-width 10rem
   z-index 3
 
-  img
+  img[alt="avatar"]
     width: 10rem;
     height: 10rem;
     object-fit: cover;


### PR DESCRIPTION
去除多余选择器后会导致文章内容中的图片显示大小出问题