### PR TITLE
remove unnecessary event listening

### DIFF
--- a/source/js/lazyload.js
+++ b/source/js/lazyload.js
@@ -32,18 +32,22 @@
 				})(i);
 			}
 		}
+		if (images.length === 0) {
+			window.removeEventListener('scroll', imageLazyLoader)
+		}
 	}
 
 	function throttle(method, context) {
 		clearTimeout(method.tId);
 		method.tId = setTimeout(function () {
-				method.call(context);
+			method.call(context);
 		}, 100);
 	}
 
 	processImages();
-
-	window.addEventListener('scroll', function () {
+	let imageLazyLoader = function () {
 		throttle(processImages, window);
-	});
+	};
+
+	window.addEventListener('scroll', imageLazyLoader);
 })(this);


### PR DESCRIPTION
当加载完所有图片后，关闭lazyload的事件监听