### PR TITLE
Fix a math display error on Chrome/Egge

### DIFF
--- a/layout/_partial/plugins/math.ejs
+++ b/layout/_partial/plugins/math.ejs
@@ -11,7 +11,12 @@
               skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
           }
       });
-
+      MathJax.Hub.Register.StartupHook("End Jax",function () {
+        var BROWSER = MathJax.Hub.Browser;
+        var jax = "HTML-CSS";
+        if (BROWSER.isMSIE && BROWSER.hasMathPlayer) jax = "NativeMML";
+        return MathJax.Hub.setRenderer(jax);
+      });
       MathJax.Hub.Queue(function() {
           var all = MathJax.Hub.getAllJax(), i;
           for(i=0; i < all.length; i += 1) {


### PR DESCRIPTION
it seems that when using the default `CommonHTML` as output will cause strange math display for `mathjax` on chrome and edge.
 
May be we can change default to  `HTML-CSS` and use `NativeMML` for IE with MathPlayer support.
before:
![image](https://user-images.githubusercontent.com/3437889/77756087-7977e900-7069-11ea-9312-7dc6455f24e0.png)
after:
![image](https://user-images.githubusercontent.com/3437889/77756095-7da40680-7069-11ea-92cf-dd4040534463.png)
