### PR TITLE
fix a bug that Tencent Analytics is always included

### DIFF
--- a/layout/_partial/plugins/analytics.ejs
+++ b/layout/_partial/plugins/analytics.ejs
@@ -33,7 +33,7 @@
     </script>
   <% } %>
 
-  <% if(theme.web_analytics.tencent.sid) { %>
+  <% if(theme.web_analytics.tencent && theme.web_analytics.tencent.sid && theme.web_analytics.tencent.cid) { %>
     <!-- Tencent Analytics -->
     <script defer>
       var _mtac = {};

--- a/layout/_partial/plugins/analytics.ejs
+++ b/layout/_partial/plugins/analytics.ejs
@@ -33,7 +33,7 @@
     </script>
   <% } %>
 
-  <% if(theme.web_analytics.tencent) { %>
+  <% if(theme.web_analytics.tencent.sid) { %>
     <!-- Tencent Analytics -->
     <script defer>
       var _mtac = {};


### PR DESCRIPTION
Tencent Analytics will always be included and loaded no matter you set 
```
  tencent:  
    sid:  SOME SID
    cid:
```
or not.

Since `theme.web_analytics.tencent` have child key `theme.web_analytics.tencent.sid` and not setting `theme.web_analytics.tencent.sid` means that the Tencent Analytics should not be included. 

We should always check `theme.web_analytics.tencent.sid` here.