### PR TITLE
增加搜索时关键词高亮 (暂不支持自定义配置)

### DIFF
--- a/source/js/local-search.js
+++ b/source/js/local-search.js
@@ -109,7 +109,7 @@ var searchFunc = function(path, search_id, content_id) {
               // highlight all keywords
               keywords.forEach(function(keyword) {
                 var regS = new RegExp(keyword, 'gi');
-                match_content = match_content.replace(regS, '<span class=\'pink-text\'>' + keyword + '</span>');
+                match_content = match_content.replace(regS, '<span class=\'pink-text\' style=\'color:red\'>' + keyword + '</span>');
               });
 
               str += '<p class=\'search-list-content\'>' + match_content + '...</p>';


### PR DESCRIPTION
在使用本地搜索功能时，关键词无法明显的显示，因此在js中主动增加样式使它高亮