### PR TITLE
修复bug

### DIFF
--- a/layout/_partial/comments/gitalk.ejs
+++ b/layout/_partial/comments/gitalk.ejs
@@ -12,7 +12,7 @@
           admin: <%- JSON.stringify(theme.gitalk.admin || []) %>,
           id: md5(<%= theme.gitalk.id %>),
           language: '<%= theme.gitalk.language %>',
-          labels: <%- JSON.stringify(theme.gitalk.labels || []) %>,
+          labels: '{{ theme.gitalk.labels }}'.split(',').filter(l => l),
           perPage: <%= theme.gitalk.perPage %>,
           pagerDirection: '<%= theme.gitalk.pagerDirection %>',
           createIssueManually: <%= theme.gitalk.createIssueManually %>,


### PR DESCRIPTION
gitalk出现
```
Error: u.concat(...).join is not a function!
```
修改后就正常了