### PR TITLE
💉使Fluid支持简繁转换

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -75,6 +75,9 @@ font:  # 主题字体配置
   code_font_size: 85%               # 代码的字号
 
 
+tran: #支持博客的简繁转换，默认开启
+  enable: true
+
 custom_js:   # 指定自定义 js 文件路径，路径是相对 source 目录，如 /js/custom.js 对应存放目录 source/js/custom.js，支持列表
 custom_css:   # 指定自定义 css 文件路径，路径是相对 source 目录，如 /css/custom.css 同上，支持列表
 custom_html: ''  # 自定义底部 HTML 内容（位于 footer 上方），也可用于外部引入 js css 这些操作，注意不要和 post.custom 配置冲突

--- a/_config.yml
+++ b/_config.yml
@@ -74,8 +74,6 @@ font:  # 主题字体配置
   font_family:                      # 全局字体
   code_font_size: 85%               # 代码的字号
 
-tran: #支持博客的简繁转换，默认开启
-  enable: true
 
 custom_js:   # 指定自定义 js 文件路径，路径是相对 source 目录，如 /js/custom.js 对应存放目录 source/js/custom.js，支持列表
 custom_css:   # 指定自定义 css 文件路径，路径是相对 source 目录，如 /css/custom.css 同上，支持列表

--- a/_config.yml
+++ b/_config.yml
@@ -74,6 +74,9 @@ font:  # 主题字体配置
   font_family:                      # 全局字体
   code_font_size: 85%               # 代码的字号
 
+tran: #支持博客的简繁转换，默认开启
+  enable: true
+
 custom_js:   # 指定自定义 js 文件路径，路径是相对 source 目录，如 /js/custom.js 对应存放目录 source/js/custom.js，支持列表
 custom_css:   # 指定自定义 css 文件路径，路径是相对 source 目录，如 /css/custom.css 同上，支持列表
 custom_html: ''  # 自定义底部 HTML 内容（位于 footer 上方），也可用于外部引入 js css 这些操作，注意不要和 post.custom 配置冲突

--- a/layout/_partial/nav.ejs
+++ b/layout/_partial/nav.ejs
@@ -59,6 +59,11 @@
                 class="iconfont icon-dark" id="color-toggle-icon"></i>&nbsp;</a>
           </li>
         <% } %>
+        <% if(theme.tran.enable == true) { %>
+          <li class="nav-item" id="tran">
+            <a class="nav-link" href="javascript:zh_tran(lololo);">&nbsp;语&nbsp;</a>
+          </li>
+        <% } %>
       </ul>
     </div>
   </div>

--- a/layout/_partial/scripts.ejs
+++ b/layout/_partial/scripts.ejs
@@ -35,6 +35,10 @@
   <%- js(theme.custom_js) %>
 <% } %>
 
+<% if (theme.tran.enable) { %>
+<script src="https://cdn.jsdelivr.net/gh/ChenYFan/CDN/js/ttontran/ttontran.js"></script>
+<% } %>
+
 <%- partial('_partial/plugins/tocjs.ejs') %>
 <%- partial('_partial/plugins/typed.ejs') %>
 <%- partial('_partial/plugins/anchor.ejs') %>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/53730587/89123870-2d502000-d505-11ea-883a-c70dbfc1f7b5.png)
![image](https://user-images.githubusercontent.com/53730587/89123884-4eb10c00-d505-11ea-9e6b-ae85c2261f27.png)
![image](https://user-images.githubusercontent.com/53730587/89123888-5cff2800-d505-11ea-901b-c302be918ef6.png)
通过js替换方式，实现无后端翻译，避免服务器开销。
默认按钮于Navbar上，点击即可完成语言翻译。
通过Cookie存储翻译状况，自动检测下次是否翻译。
默认js在jsdelivr上 `https://cdn.jsdelivr.net/gh/ChenYFan/CDN/js/ttontran/trontran.js` 压缩后大小10.88KB。
可通过主题config进行开关。
已通过本地测试