### PR TITLE
修复 disqus 加载失败

### DIFF
--- a/layout/_partial/comments/disqus.ejs
+++ b/layout/_partial/comments/disqus.ejs
@@ -21,11 +21,11 @@
   <div class="disqus" style="width:100%">
     <div id="disqus_thread"></div>
     <script type="text/javascript">
+      var disqus_config = function () {
+        this.page.url = '<%= page.permalink %>';
+        this.page.identifier = '/<%= page.path %>';
+      };
       function loadDisqus() {
-        var disqus_config = function () {
-          this.page.url = '<%= config.url %>/<%= page.path %>';
-          this.page.identifier = '/<%= page.path %>';
-        };
         (function () {
           var d = document,
             s = d.createElement('script');


### PR DESCRIPTION
修改变量 `disqus_config` 的声明位置。
当将 `disqus_config` 放在 `loadDisqus()` 内时，this 的指代的是 `loadDisqus()` 函数，故会出现 Disqus 无法正确加载的问题。
另外使用 `<%= page.permalink %>` 代替 `<%= config.url %>/<%= page.path %>`