### PR TITLE
waline文件requiredFields字段转义后报错问题

### DIFF
--- a/layout/_partial/comments/waline.ejs
+++ b/layout/_partial/comments/waline.ejs
@@ -14,7 +14,7 @@
           highlight: <%= theme.waline.highlight %>,
           serverURL: "<%= theme.waline.serverURL %>",
           avatarForce: <%= theme.waline.avatarForce %>,
-          requiredFields: <%= JSON.stringify(theme.waline.requiredFields || []) %>,
+          requiredFields: <%- JSON.stringify(theme.waline.requiredFields || []) %>,
           emojiCDN: "<%= theme.waline.emojiCDN %>",
           emojiMaps: <%- JSON.stringify(theme.waline.emojiMaps) %>,
         });


### PR DESCRIPTION
看了下原作者的文件，meta和requiredFields字段的值是一样的，但是requiredFields加了转义后输出，这样配置后会报 Unexpected token ‘&’ 错误，所以改了下和meta保持一致了