### PR TITLE
由用户指定页面的description

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -17,7 +17,13 @@ if (page.title) {
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <% } %>
   <meta name="theme-color" content="<%- theme.color.navbar_bg_color %>">
-  <meta name="description" content="<%= config.description %>">
+  <% if (page.description) { %>
+    <meta name="description" content="<%= page.description %>">
+  <% } else if(page.excerpt){ %> 
+    <meta name="description" content="<%= strip_html(page.excerpt).substr(0, 200) %>">
+  <% } else { %>
+    <meta name="description" content="<%= config.description %>">
+  <% } %>
   <meta name="author" content="<%= page.author || config.author %>">
   <meta name="keywords" content="<%= config.keywords %>">
   <title><%= title %></title>

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -28,7 +28,9 @@ page.banner_mask_alpha = theme.index.banner_mask_alpha
       <p class="index-excerpt">
         <a href="<%- post_url %>">
           <% var excerpt = '' %>
-          <% if(post.excerpt) { %>
+          <% if(post.description) { %>
+            <% excerpt = post.description %>
+          <% } else if(post.excerpt){ %>
             <% excerpt = strip_html(post.excerpt).substr(0, 200) %>
           <% } else if(theme.index.auto_excerpt.enable){ %>
             <% excerpt = strip_html(post.content).substr(0, 200) %>


### PR DESCRIPTION
# 添加/修改 的功能
- 由用户指定文章页面的description
- 文章节选默认获取文章的description属性

# 功能-文章节选默认获取文章的description属性
## 效果对比  
  
修改前：
![image](https://user-images.githubusercontent.com/46259392/106138476-2732b780-61a7-11eb-9d54-cb4a04cf2f84.png)
---
修改后：
![image](https://user-images.githubusercontent.com/46259392/106138578-46c9e000-61a7-11eb-8c68-72cafcfd3eae.png)

## 优劣对比
原版：
- 优：无需额外在MD中设置属性；更加方便简洁；通常情况下也能较好的表述文章的大致内容，节省用户额外概括的时间。
- 劣： 对于长话开篇的情况，单纯的内容截取可能无法完全的表达文章的具体内容；可能将大标题也截入，无标点的情况下影响句子的通畅性。  
  
改版： 
- 优：可以完全的表达文章的大致内容（取决于用户的概括能力）；看上去更简洁精炼。
- 劣：额外的MD属性，可能影响代码的简洁性；需要使用者自行概括。

# 功能-由用户指定文章页面的description  
## 效果对比  
  
该项修改无论是对于博主亦或是访客都无直观上的变化，仅出现在源代码中。  
**但是**对于搜索引擎的收录是有好处的。虽然不是直接对SEO的优化，但是对description 的指定将改变诸如百度，谷歌等搜索引擎对文章内容的摘录，从而使访问者在搜索引擎搜索时能够更明确的文章的大致内容，从而增加访客量。
  
原版：
![image](https://user-images.githubusercontent.com/46259392/106140445-c0fb6400-61a9-11eb-99c0-e2f0465500c4.png)
对标题的摘录影响句子的通畅性。
---
改版：
![image](https://user-images.githubusercontent.com/46259392/106140632-f99b3d80-61a9-11eb-9ecb-3d074f1f6ae4.png)

# 其他
就我个人而言，我觉得这样的额外配置是很有必要的。虽然博主可能需要花额外的时间，但方便了用户的阅读，避免了无用的点击也增加了针对的点击。
其实我个人认为，原版的文章截取更类似于以前的 内容截取—展开全文 的逻辑；而修改后则是侧重于文章内容的概括：更针对用户的阅读体验。  
不可避免的不同人肯定有不同的侧重方向，所以预想的改动是额外在config配置文件中添加相应的选项供博主自行抉择。然而我并不确定您是否有添加该功能的意向，也就暂时先做到这一步了。



