### PR TITLE
修复waline加载失败，并更新waline静态资源

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -965,7 +965,7 @@ static_prefix:
 
   valine: https://cdn.jsdelivr.net/npm/valine@1.4.14/dist/
 
-  waline: https://cdn.jsdelivr.net/npm/@waline/client@0.4.2/dist/
+  waline: https://cdn.jsdelivr.net/npm/@waline/client@0.14.8/dist/
 
   gitalk: https://cdn.jsdelivr.net/npm/gitalk@1.7.0/dist/
 

--- a/layout/_partial/comments/waline.ejs
+++ b/layout/_partial/comments/waline.ejs
@@ -18,7 +18,7 @@
           requiredFields: <%- JSON.stringify(theme.waline.requiredFields || []) %>,
           emojiCDN: "<%= theme.waline.emojiCDN %>",
           emojiMaps: <%- JSON.stringify(theme.waline.emojiMaps) %>,
-          anonymous: <%= theme.waline.anonymous %>,
+          anonymous: <%= JSON.stringify(theme.waline.anonymous) %>,
         });
       });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-theme-fluid",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "An elegant Material-Design theme for Hexo.",
   "main": "gulpfile.js",
   "scripts": {


### PR DESCRIPTION
waline新增anonymous配置项。  
根据官方文档，anonymous默认值为：` `  

而`layout/_partial/comments/waline.ejs`中渲染代码如下：
```
anonymous: <%= theme.waline.anonymous %>,
```

当anonymous为默认值时，渲染为空，导致渲染出的js代码`Uncaught SyntaxError: Unexpected token ','`异常。

![](https://user-images.githubusercontent.com/14837139/111345392-32d73080-86b8-11eb-8bd3-8fe54d6c40a9.png)


