### PR TITLE
修改1.8.9版本中请求不到头像时显示不了默认头像的问题

### DIFF
--- a/layout/links.ejs
+++ b/layout/links.ejs
@@ -16,7 +16,7 @@ page.banner_mask_alpha = theme.links.banner_mask_alpha
           <% if (each.avatar || each.image) { %>
             <div class="link-avatar my-auto">
               <img src="<%= each.avatar || each.image %>" alt="<%= each.title %>"
-                   onerror="this.onerror=null; this.srcset=null; this.src='<%= theme.links.onerror_avatar %>'"/>
+                   onerror="this.onerror=null;this.src='<%= theme.links.onerror_avatar %>'"/>
             </div>
           <% } %>
           <div class="link-text">


### PR DESCRIPTION
请求不到头像时本应该显示设置的默认的头像，
但是在1.8.9中无法显示，是srcset的问题，看源码是设置为null，
因此修改把srcset删掉！！
修改后可以显示默认头像。