### PR TITLE
🔧 增加必要的peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
   "engines": {
     "node": ">=8.10.0"
   },
+  "peerDependencies": {
+    "hexo-renderer-ejs": "^1.0",
+    "hexo-renderer-stylus": "^2.0",
+    "nunjucks": "^3.0"
+  },
   "devDependencies": {
     "ejs-lint": "^1.1.0",
     "gulp": "^4.0.2",


### PR DESCRIPTION
Fluid主题源码中使用了ejs和stylus，如果博客主工程里没有添加相应的renderer插件的话就会渲染异常。考虑到用户之前使用的主题未必使用ejs、stylus，因此可能会没有安装相应的renderer插件，因此增加peerDependencies以在安装时提示用户。

另外，local-search功能中也依赖了nunjucks库，因此同样添加到peerDependencies中（相关issue：#475）。