### PR TITLE
增加updated字段显示功能

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -469,6 +469,7 @@ index:
   # Meta information of post
   post_meta:
     date: true
+    updated: true
     category: true
     tag: true
 
@@ -501,9 +502,13 @@ post:
       enable: false
 
     # 文章日期，优先根据 front-matter 里 date 字段，其次是 md 文件日期
+    # updated_enable 显示 front-matter 里 updated 字段，如果updated晚于date。如果enable，则用两个单词区别两行日期。
     # Post date, based on `date` field in front-matter, if not set, based on create date of .md file
+    # updated_enable displays `updated` field in front-matter if it's later than `date`.If you enabled updated,two words to distinguish date and updated are needed.
     date:
       enable: true
+      updated_enable: true
+      date_updated_words: ['创建', '更新']
       # 格式参照 ISO-8601 日期格式化
       # ISO-8601 date format
       # See: http://momentjs.cn/docs/#/parsing/string-format/

--- a/layout/_partial/post-meta.ejs
+++ b/layout/_partial/post-meta.ejs
@@ -11,6 +11,21 @@
       <time datetime="<%= full_date(page.date, 'YYYY-MM-DD HH:mm') %>" pubdate>
         <%= full_date(page.date, theme.post.meta.date.format) %>
       </time>
+      <% if (theme.post.meta.date.updated_enable && (page.updated > page.date)) { %>
+        <%- theme.post.meta.date.date_updated_words[0] %>
+      <% } %>
+    </span>
+  <% } %>
+</div>
+
+<div class="mt-3">
+  <% if (theme.post.meta.date.updated_enable && (page.updated > page.date)) { %>
+    <span class="post-meta">
+      <i class="iconfont icon-pen" aria-hidden="true"></i>
+      <time datetime="<%= full_date(page.updated, 'YYYY-MM-DD HH:mm') %>" pubdate>
+        <%= full_date(page.updated, theme.post.meta.date.format) %>
+      </time>
+      <%- theme.post.meta.date.date_updated_words[1] %>
     </span>
   <% } %>
 </div>

--- a/layout/_partial/post-meta.ejs
+++ b/layout/_partial/post-meta.ejs
@@ -18,7 +18,7 @@
   <% } %>
 </div>
 
-<div class="mt-3">
+<div class="mt-1">
   <% if (theme.post.meta.date.updated_enable && (page.updated > page.date)) { %>
     <span class="post-meta">
       <i class="iconfont icon-pen" aria-hidden="true"></i>

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -50,6 +50,14 @@ page.banner_mask_alpha = theme.index.banner_mask_alpha
             </time>
           </div>
         <% } %>
+        <% if(theme.index.post_meta.updated && (post.updated > post.date)) { %>
+          <div class="post-meta mr-3">
+            <i class="iconfont icon-pen"></i>
+            <time datetime="<%= full_date(post.updated, 'YYYY-MM-DD HH:mm') %>" pubdate>
+              <%- date(post.updated, config.date_format) %>
+            </time>
+          </div>
+        <% } %>
         <% if(theme.index.post_meta.category && post.categories.length > 0) { %>
           <div class="post-meta mr-3">
             <i class="iconfont icon-category"></i>


### PR DESCRIPTION
改动目标：
1. 首页的每篇文章除了创建时间之外还能显示文档更新时间。
2. 点进每篇文章之后都会显示创建时间和更新时间。

改动1：
主题配置文件中post_meta加入`updated = true`
在主题的layout文件夹index.ejs内的`class="index-btm post-metas"`的代码块加入代码，让主页显示文章更新时间。

改动2：
主题配置post部分仿照date加入updated选项。
在post-meta.ejs代码中增加文章最近修改时间updated显示。

效果如下
<img width="637" alt="index显示updated" src="https://user-images.githubusercontent.com/56628462/120927079-30fa9780-c712-11eb-99c0-20f9d1369973.png">
<img width="1163" alt="post显示updated" src="https://user-images.githubusercontent.com/56628462/120927082-322bc480-c712-11eb-81be-a4d7211fed62.png">
