### PR TITLE
为评论图片添加 fancybox 支持（以 Twikoo 为例）

### DIFF
--- a/layout/_partial/comments/twikoo.ejs
+++ b/layout/_partial/comments/twikoo.ejs
@@ -7,7 +7,12 @@
           <%- JSON.stringify(theme.twikoo || {}) %>,
           {
             el: '#twikoo',
-            path: '<%= theme.twikoo.path %>'
+            path: '<%= theme.twikoo.path %>',
+            onCommentLoaded: function () {
+              Fluid.plugins.initFancyBox({
+                isTwikoo: true
+              });
+            }
           }
         )
         twikoo.init(options)

--- a/source/js/plugins.js
+++ b/source/js/plugins.js
@@ -55,10 +55,15 @@ Fluid.plugins = {
     }
   },
 
-  initFancyBox: function() {
+  initFancyBox: function(option) {
     if (!$.fancybox) { return; }
 
-    jQuery('.markdown-body :not(a) > img, .markdown-body > img').each(function() {
+    var $imageSel = '.markdown-body :not(a) > img, .markdown-body > img'
+    if (option.isTwikoo) {
+      $imageSel = '#twikoo img:not(.tk-avatar-img)'
+    }
+
+    jQuery($imageSel).each(function() {
       var $image = jQuery(this);
       var imageUrl = $image.attr('data-src') || $image.attr('src') || '';
       if (CONFIG.image_zoom.img_url_replace) {

--- a/source/js/plugins.js
+++ b/source/js/plugins.js
@@ -61,7 +61,7 @@ Fluid.plugins = {
     var option = param || {};
     var $imageSel = '.markdown-body :not(a) > img, .markdown-body > img';
     if (option.isTwikoo) {
-      $imageSel = '#twikoo img:not(.tk-avatar-img)';
+      $imageSel = '#twikoo .tk-content img:not(.tk-owo-emotion)';
     }
 
     jQuery($imageSel).each(function() {

--- a/source/js/plugins.js
+++ b/source/js/plugins.js
@@ -55,12 +55,13 @@ Fluid.plugins = {
     }
   },
 
-  initFancyBox: function(option) {
+  initFancyBox: function(param) {
     if (!$.fancybox) { return; }
 
-    var $imageSel = '.markdown-body :not(a) > img, .markdown-body > img'
+    var option = param || {};
+    var $imageSel = '.markdown-body :not(a) > img, .markdown-body > img';
     if (option.isTwikoo) {
-      $imageSel = '#twikoo img:not(.tk-avatar-img)'
+      $imageSel = '#twikoo img:not(.tk-avatar-img)';
     }
 
     jQuery($imageSel).each(function() {


### PR DESCRIPTION
评论系统的图片不能点击放大，主题本身自带 fancybox，所以想在评论系统中引用 fancybox 提供评论图片点击放大功能。