### PR TITLE
feature: Add Open Graph to the head

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -27,6 +27,9 @@ if (page.description) {
   <meta name="description" content="<%= description %>">
   <meta name="author" content="<%= page.author || config.author %>">
   <meta name="keywords" content="<%= keywords %>">
+  <%- open_graph({
+    twitter_card: "summary_large_image"
+  }) %>
   <% if (theme.custom_head) { %>
     <%- theme.custom_head %>
   <% } %>


### PR DESCRIPTION
Add Open Graph to the head to support Twitter Card.

It would be like the below screenshot. I hope you guys like that.

<img width="439" alt="image" src="https://user-images.githubusercontent.com/3297859/129431962-338581ce-7954-4aa2-a33f-17d6e237ce5b.png">

Feel free to close PR if it isn't needed.

Refs:
- https://hexo.io/docs/helpers.html#open-graph
- https://cards-dev.twitter.com/validator