### PR TITLE
seo: page meta controls og:image 

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -11,7 +11,7 @@ if (page.description) {
 } else if(page.excerpt) {
   description = strip_html(page.excerpt).substr(0, 200)
 }
-var og = Object.assign({image: page.index_img}, theme.open_graph)
+var og = Object.assign({image: page.og_img}, theme.open_graph)
 %>
 
 <head>


### PR DESCRIPTION
Allow meta tags on page/post to override the default og:image for SEO/social sharing reasons