### PR TITLE
seo: fix og:img path by using url_for(...)

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -13,7 +13,7 @@ if (page.description) {
 } else if (is_post()) {
   description = strip_html(page.content).substr(0, 200)
 }
-var ogConfig = Object.assign({ image: page.og_img || page.index_img }, theme.open_graph)
+var ogConfig = Object.assign({ image: url_for(page.og_img) || url_for(page.index_img) }, theme.open_graph)
 %>
 
 <head>


### PR DESCRIPTION
Links were relative to page.
These links need to be absolute - e.g. "website.com/img/..." 