### PR TITLE
feat: add dark mode support for tag and label plugin

### DIFF
--- a/source/css/_pages/_post/tag_plugin.styl
+++ b/source/css/_pages/_post/tag_plugin.styl
@@ -51,22 +51,22 @@
   color var(--text-color)
 
 .label-default
-    background rgba(187, 187, 187, 0.2)
+  background rgba(187, 187, 187, 0.2)
 
 .label-primary
-    background rgba(183, 160, 224, 0.2)
+  background rgba(183, 160, 224, 0.2)
 
 .label-info
-    background rgba(160, 197, 228, 0.2)
+  background rgba(160, 197, 228, 0.2)
 
 .label-success
-    background rgba(174, 220, 174, 0.2)
+  background rgba(174, 220, 174, 0.2)
 
 .label-warning
-    background rgba(248, 214, 166, 0.2)
+  background rgba(248, 214, 166, 0.2)
 
 .label-danger
-    background rgba(236, 169, 167, 0.2)
+  background rgba(236, 169, 167, 0.2)
 
 // button
 .markdown-body .btn

--- a/source/css/_pages/_post/tag_plugin.styl
+++ b/source/css/_pages/_post/tag_plugin.styl
@@ -4,41 +4,41 @@
   border-left 0.35rem solid
   border-radius 0.25rem
   margin 1.5rem 0
-  color $text-color
+  color var(--text-color)
   font-size 0.9rem
 
   a
-    color $text-color
+    color var(--text-color)
 
   *:last-child
     margin-bottom 0
 
 .note-primary
-  background-color #f5f0fa
+  background-color rgba(183, 160, 224, 0.2)
   border-color #6f42c1
 
 .note-secondary, note-default
-  background-color #f7f7f7
+  background-color rgba(187, 187, 187, 0.2)
   border-color #777
 
 .note-success
-  background-color #eff8f0
+  background-color rgba(174, 220, 174, 0.2)
   border-color #5cb85c
 
 .note-danger
-  background-color #fcf1f2
+  background-color rgba(236, 169, 167, 0.2)
   border-color #d9534f
 
 .note-warning
-  background-color #fdf8ea
+  background-color rgba(248, 214, 166, 0.2)
   border-color #f0ad4e
 
 .note-info
-  background-color #eef7fa
+  background-color rgba(160, 197, 228, 0.2)
   border-color #428bca
 
 .note-light
-  background-color #fefefe
+  background-color rgba(254, 254, 254, 0.2)
   border-color #0f0f0f
 
 // label
@@ -48,25 +48,31 @@
   font-size 85%
   margin 0
   padding .2em .4em
-  color $text-color
+  color var(--text-color)
 
 .label-default
-  background #f7f7f7
+    background rgba(187, 187, 187, 0.2)
+//   background #f7f7f7
 
 .label-primary
-  background #f5f0fa
+    background rgba(183, 160, 224, 0.2)
+//   background #f5f0fa
 
 .label-info
-  background #eef7fa
+    background rgba(160, 197, 228, 0.2)
+//   background #eef7fa
 
 .label-success
-  background #eff8f0
+    background rgba(174, 220, 174, 0.2)
+//   background #eff8f0
 
 .label-warning
-  background #fdf8ea
+    background rgba(248, 214, 166, 0.2)
+//   background #fdf8ea
 
 .label-danger
-  background #fcf1f2
+    background rgba(236, 169, 167, 0.2)
+//   background #fcf1f2
 
 // button
 .markdown-body .btn

--- a/source/css/_pages/_post/tag_plugin.styl
+++ b/source/css/_pages/_post/tag_plugin.styl
@@ -52,27 +52,21 @@
 
 .label-default
     background rgba(187, 187, 187, 0.2)
-//   background #f7f7f7
 
 .label-primary
     background rgba(183, 160, 224, 0.2)
-//   background #f5f0fa
 
 .label-info
     background rgba(160, 197, 228, 0.2)
-//   background #eef7fa
 
 .label-success
     background rgba(174, 220, 174, 0.2)
-//   background #eff8f0
 
 .label-warning
     background rgba(248, 214, 166, 0.2)
-//   background #fdf8ea
 
 .label-danger
     background rgba(236, 169, 167, 0.2)
-//   background #fcf1f2
 
 // button
 .markdown-body .btn


### PR DESCRIPTION
实现 #558 

重新计算颜色并调整 alpha 替代 tag plugin 相关的 `background-color`。 在 light mode 和 dark mode 均有不错效果。

顺便也修改了 inline label 的效果。

## 效果

![light mode](https://user-images.githubusercontent.com/32197833/150126586-069a0bc8-4056-4334-8f17-675264d10518.png)
![dark mode](https://user-images.githubusercontent.com/32197833/150126626-dbebe8b7-81d5-43a5-9bb2-56b327db6318.png)
