### PR TITLE
增加对 Cloudflare Web Analytics 服务的支持

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -266,6 +266,8 @@ web_analytics:  # 网页访问统计
     # If ture, ignore localhost & 127.0.0.1
     ignore_local: false
 
+  cloudflare:
+  
 # 对页面中的图片和评论插件进行懒加载处理，可见范围外的元素不会提前加载
 # Lazy loading of images and comment plugin on the page
 lazyload:

--- a/layout/_partial/plugins/analytics.ejs
+++ b/layout/_partial/plugins/analytics.ejs
@@ -63,4 +63,10 @@
     <script defer src="//s4.cnzz.com/z_stat.php?id=<%- theme.web_analytics.cnzz %>&show=pic"
             type="text/javascript"></script>
   <% } %>
+
+  <% if(theme.web_analytics.cloudflare) { %>
+    <!--Cloudflare Web Analytics-->
+    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "<%= theme.web_analytics.cloudflare %>"}'></script>
+  <% } %>
+
 <% } %>


### PR DESCRIPTION
该服务的跟踪代码较为复杂，需要同时用到单引号和双引号，无法使用自定义 HTML 的方式添加。
该服务的原始跟踪代码以如下形式提供：
```html
<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "TRACKINGID"}'></script><!-- End Cloudflare Web Analytics -->
```
其中的 `TRACKINGID` 部分即为需要在主题配置文件中填写的跟踪 ID.