### PR TITLE
[fix]:修复checkbox为false时与true的checkbox右边界不对齐的问题

### DIFF
--- a/source/css/_pages/_base/rewrite.styl
+++ b/source/css/_pages/_base/rewrite.styl
@@ -430,7 +430,7 @@ input[type=checkbox]
   transition .2s
   color #fff
   cursor pointer
-  margin .4rem .2rem .4rem !important
+  margin .4rem .5rem .4rem .2rem !important
   outline 0
   border-radius 0.1875rem
   vertical-align -.65rem


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/61926575/162613999-f9ab2284-3255-428f-a387-50a761e3a5d4.png)
如上图，在iPhone 15.4 Safari 和 Linux Manjaro 5.13.19-2 google-chrome 100.0.4896.60-1均会出现这个问题。