### PR TITLE
📝配置文件中增加指定渲染方式的配置项

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -707,6 +707,9 @@ post:
     # Options: mathjax | katex
     engine: mathjax
 
+    # 指定mathjax的渲染方式，默认通过'es5/tex-svg.js'进行渲染
+    render: 'es5/tex-svg.js'
+
   # 流程图，基于 mermaid-js，具体请见：https://hexo.fluid-dev.com/docs/guide/#mermaid-流程图
   # Flow chart, based on mermaid-js, see: https://hexo.fluid-dev.com/docs/en/guide/#mermaid
   mermaid:

--- a/layout/_partials/plugins/math.ejs
+++ b/layout/_partials/plugins/math.ejs
@@ -38,7 +38,7 @@
       </script>
     `)
 
-    import_js(theme.static_prefix.mathjax.replace('es5/', ''), 'es5/tex-mml-chtml.js')
+    import_js(theme.static_prefix.mathjax.replace('es5/', ''), theme.post.math.render || 'es5/tex-svg.js')
   %>
 
 <% } else if (theme.post.math.engine === 'katex') { %>


### PR DESCRIPTION
最近版本中发现mathjax默认通过CHTML, 新增了配置项，可以通过配置指定具体的渲染方式，默认渲染方式设置为SVG