### PR TITLE
fix wrong switch-case conditions in scope.js

### DIFF
--- a/scripts/helpers/scope.js
+++ b/scripts/helpers/scope.js
@@ -1,31 +1,37 @@
 /* global hexo */
 
-'use strict';
+"use strict";
 
 const pageInScope = (page, scope) => {
   switch (scope) {
-    case 'home':
+    case "home":
       return Boolean(page.__index);
-    case 'post':
+    case "post":
+    case "posts":
       return Boolean(page.__post);
-    case 'archives' || 'archive':
+    case "archives":
+    case "archive":
       return Boolean(page.archive);
-    case 'categories' || 'category':
-      return page.layout === 'categories' || page.layout === 'category';
-    case 'tags' || 'tag':
-      return page.layout === 'tags' || page.layout === 'tag';
-    case 'about':
-      return page.layout === 'about';
-    case 'links' || 'link':
-      return page.layout === 'links';
-    case '404':
-      return page.layout === '404';
-    case 'page' || 'custom':
+    case "categories":
+    case "category":
+      return page.layout === "categories" || page.layout === "category";
+    case "tags":
+    case "tag":
+      return page.layout === "tags" || page.layout === "tag";
+    case "about":
+      return page.layout === "about";
+    case "links":
+    case "link":
+      return page.layout === "links";
+    case "404":
+      return page.layout === "404";
+    case "page":
+    case "custom":
       return Boolean(page.__page);
   }
 };
 
-hexo.extend.helper.register('in_scope', function(scope) {
+hexo.extend.helper.register("in_scope", function (scope) {
   if (!scope || scope.length === 0) {
     return true;
   }


### PR DESCRIPTION
It was written originally like
```js
case 'categories' || 'category':
      return page.layout === 'categories' || page.layout === 'category';
```
However, ('categories' || 'category') is equal to 'categories'(`js short-circuit evaluation`).
so category will not take effect. 😄