### PR TITLE
添加了导航栏logo和额外设置

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -101,6 +101,10 @@ fun_features:
     # Enable in specified page, all pages by default
     # Options: home | post | tag | category | about | links | page | 404
     scope: []
+    
+    # 使typed.js自动插入CSS，关闭可以关闭光标的闪烁效果
+    # Let typed.js insert CSS automatically, turning this off turns off the blinking effect of the cursor
+    autoInsertCss: true
 
   # 为文章内容中的标题添加锚图标
   # Add an anchor icon to the title on the post page

--- a/_config.yml
+++ b/_config.yml
@@ -328,6 +328,23 @@ iconfont: //at.alicdn.com/t/font_1736178_lbnruvf0jn.css
 # 导航栏的相关配置
 # Navigation bar
 navbar:
+  # 显示导航栏 logo
+  # Displays a logo on the navbar
+  logo:
+    enable: true
+
+    # logo 图片的路径
+    # Path of the logo image
+    file: "/img/fluid.png"
+
+    # logo 图片的大小(单位自带)
+    # Size of the logo image(unit needed)
+    size: "2rem"
+
+    # logo 图片距离文字的边距(单位自带)
+    # CSS padding-right of the logo image(unit needed)
+    padding_right: "0.5rem"
+
   # 导航栏左侧的标题，为空则按 hexo config 中 `title` 显示
   # The title on the left side of the navigation bar. If empty, it is based on `title` in hexo config
   blog_title: "Fluid"

--- a/layout/_partials/header/navigation.ejs
+++ b/layout/_partials/header/navigation.ejs
@@ -1,7 +1,12 @@
 <nav id="navbar" class="navbar fixed-top  navbar-expand-lg navbar-dark scrolling-navbar">
   <div class="container">
     <a class="navbar-brand" href="<%= url_for() %>">
-      <strong><%= theme.navbar.blog_title || config.title %></strong>
+      <div class="navbar-brand">
+        <% if (theme.navbar.logo.enable) { %>
+	<img class="navbar-logo" src="<%= theme.navbar.logo.file %>" />
+	<% } %>
+        <strong><%= theme.navbar.blog_title || config.title %></strong>
+      </div>
     </a>
 
     <button id="navbar-toggler-btn" class="navbar-toggler" type="button" data-toggle="collapse"

--- a/source/css/_pages/_base/_widget/header.styl
+++ b/source/css/_pages/_base/_widget/header.styl
@@ -8,6 +8,10 @@
   .navbar-brand
     color var(--navbar-text-color)
 
+  img.navbar-logo
+    height $navbar-logo-height
+    padding-right $navbar-logo-padding
+
   .navbar-toggler .animated-icon span
     background-color var(--navbar-text-color)
 

--- a/source/css/_variables/base.styl
+++ b/source/css/_variables/base.styl
@@ -40,6 +40,8 @@ $navbar-text-color-dark = theme-config("color.navbar_text_color_dark", "d0d0d0")
 $navbar-glass-enable = theme-config-origin("navbar.ground_glass.enable", false)
 $navbar-glass-px = theme-config-unit("navbar.ground_glass.px", 0, "px")
 $navbar-glass-alpha = theme-config-origin("navbar.ground_glass.alpha", 0)
+$navbar-logo-height = theme-config("navbar.logo.size", "2rem")
+$navbar-logo-padding = theme-config("navbar.logo.padding_right", "0.5rem")
 
 // banner
 $banner-width-height-ratio = theme-config-origin("banner.width_height_ratio", 0)

--- a/source/js/plugins.js
+++ b/source/js/plugins.js
@@ -18,7 +18,8 @@ Fluid.plugins = {
       ],
       cursorChar: CONFIG.typing.cursorChar,
       typeSpeed : CONFIG.typing.typeSpeed,
-      loop      : CONFIG.typing.loop
+      loop      : CONFIG.typing.loop,
+      autoInsertCss: CONFIG.typing.autoInsertCss
     });
     typed.stop();
     var subtitle = document.getElementById('subtitle');


### PR DESCRIPTION
# 总览
该修改涉及以下方面：
* 添加了导航栏的 Logo
* 在配置文件中添加了 Typed.js 中 `autoInsertCss` 选项的设置

# 分述
## 导航栏 Logo
在顶部导航栏 `div.navbar-brand` 内文字前添加了一个 `<img>` 标签。  

### 效果
![image](https://user-images.githubusercontent.com/53754724/178299092-85519e97-e467-4eb8-bf0c-01398e154edb.png)

### 关于“单位自带”
因各种设备拥有繁复的各种 dpi、屏幕尺寸与比例，Logo 图片的大小不好以非相对单位 `px` 把握，本人使用 `rem` 单位配置 Logo 图片。而考虑到 `px` 以及其他单位确有用处，且主题用户大多未接触过 `rem` 单位，因此，依我拙见，此处单位应自带。

### 关于 CSS
在 CSS 中直接用 Stylus 变量而不是 CSS 自带的 `var()` 是受本人技术所限，无法寻找到定义 CSS 变量的文件，因而直接采用 Stylus 变量。  
而 `标签.类名` 的选择器形式仅个人习惯，在 pr 时实无兴趣重新更改提交。  
见谅。

## 关于 autoInsertCss
使 Typed.js 不自动插入 CSS 代码后，即可使光标不闪烁。  
经本人测试，不会对采用 Fluid 的页面产生**任何** 除光标不闪烁外 的效果。  

## Demo
以上二修改项的效果均可在 [[我的博客](https://lingrottin.uof.edu.kg)]（[[备用链接](https://lingrottin.pages.dev)]） 看到。
<br />
（因为错误提交了 merge 到 `master` 的请求，重新提交了一遍）
辛苦了。