### PR TITLE
添加萌娘百科黑幕效果

### DIFF
--- a/scripts/tags/heimu.js
+++ b/scripts/tags/heimu.js
@@ -1,0 +1,16 @@
+/* global hexo */
+
+'use strict';
+
+const heimu = (args) => {
+  args = args.join(' ').split('@');
+  const title = args[0] || '你知道的太多了';
+  const text = args[1] || '';
+
+  !text && hexo.log.warn('[Fluid] Heimu text must be defined!');
+
+  return `<span class="heimu" title="${title.trim()}">${text}</span>`;
+};
+
+// {% heimu title @text %}
+hexo.extend.tag.register('heimu', heimu, { ends: false });


### PR DESCRIPTION
另还有一段 CSS，与项目的许可证有些许冲突，故应让用户自行选用：

```css
 /* 萌娘百科 “黑幕” */
 /* 以下内容引用自萌娘百科 https://zh.moegirl.org.cn/MediaWiki:Gadget-site-styles.css，感谢！ */
 /* MoeGirl Start */
 
.heimu,
.heimu a,
a .heimu,
a.new .heimu,
span.heimu a.new,
span.heimu a.external,
span.heimu a.external:visited,
span.heimu a.extiw,
span.heimu a.extiw:visited,
span.heimu a.mw-disambig,
span.heimu a.mw-redirect{
    transition:color 0.13s linear;
    color:#252525;
    text-shadow:none;
}
 
span.heimu:hover,
span.heimu:active{
    color:white;
}
 
span.heimu:hover a,
a:hover span.heimu{
    color:lightblue;
}
 
span.heimu:hover a:visited,
a:visited:hover span.heimu{
    color:#C5CAE9;
}
 
span.heimu:hover a.new,
a.new:hover span.heimu{
    color:#FCC;
}
 
span.heimu a.new:hover:visited,
a.new:hover:visited span.heimu{
    color:#EF9A9A;
}
 
span.heimu:hover a.extiw:visited,
a.extiw:visited:hover span.heimu{
    color:#D1C4E9;
}

/* MoeGirl End */
```

这段 CSS 是在 CC BY-NC-SA 3.0 下授权的。
Allow edits by maintainers.