### PR TITLE
为 post 的 Front-matter 中添加 archive 选项用于决定 post 是否在首页展示（默认仍为展示）

### DIFF
--- a/scripts/filters/post-filter.js
+++ b/scripts/filters/post-filter.js
@@ -26,10 +26,12 @@ hexo.extend.filter.register('before_generate', function() {
   });
   const hidePosts = allPosts.filter(post => post.hide);
   const normalPosts = allPosts.filter(post => !post.hide);
+  const indexPost = allPosts.filter(post => !post.archive)
 
   this.locals.set('all_posts', allPosts);
   this.locals.set('hide_posts', hidePosts);
   this.locals.set('posts', normalPosts);
+  this.locals.set('index_posts', indexPost);
 });
 
 const original_post_generator = hexo.extend.generator.get('post');

--- a/scripts/generators/index-generator.js
+++ b/scripts/generators/index-generator.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const pagination = require('hexo-pagination');
+
+module.exports = function(locals) {
+  const config = this.config;
+  const posts = locals.index_posts.sort(config.index_generator.order_by);
+
+  posts.data.sort((a, b) => (b.sticky || 0) - (a.sticky || 0));
+
+  const paginationDir = config.pagination_dir || 'page';
+  const path = config.index_generator.path || '';
+
+  return pagination(path, posts, {
+    perPage: config.index_generator.per_page,
+    layout: 'index',
+    format: paginationDir + '/%d/',
+    data: {
+      __index: true
+    }
+  });
+};

--- a/scripts/generators/pages.js
+++ b/scripts/generators/pages.js
@@ -50,3 +50,5 @@ hexo.extend.generator.register('_links', function(locals) {
     };
   }
 });
+
+hexo.extend.generator.register('index', require('./index-generator'));


### PR DESCRIPTION
这是 issue #864 的pull request。
写作过程中，我们常常遇见由于内容过多导致某个主题变成系列文章的情况，往往一个系列还包含5篇以上的文章，如果全部罗列在首页显然不是一个优雅的做法。
私以为一个优雅的解决办法是为系列文章创建一个索引 post，在启用 category_bar 的同时为索引 post 中添加同系列每篇文章的url，首页上只展示每个系列的索引 post 即可。为此，我重写并覆盖了 hexo 的 hexo-generator-index 插件（说是重写也就是做了几处修改），同时在 post_fliter 处将主页文章这一分类过滤出来。
考虑到兼容性，archive 默认关闭，不影响原有 post 渲染。