### PR TITLE
🐛 再次修复 404 页面路径

### DIFF
--- a/layout/404.ejs
+++ b/layout/404.ejs
@@ -9,7 +9,7 @@ page.banner_mask_alpha = theme.page404.banner_mask_alpha
 
 <script>
   function redirect() {
-    location.href = <%- url_for('/') %>;
+    location.href = "<%- url_for('/') %>";
   }
 
   <% if (theme.page404.redirect_delay) { %>


### PR DESCRIPTION
#855 丢失了引号？成了光杆司令
```
Uncaught SyntaxError: Invalid regular expression: missing /
```