### PR TITLE
Migrate Google tracking from UA to GA4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -252,15 +252,10 @@ web_analytics:  # 网页访问统计
   # See: https://tongji.baidu.com/sc-web/10000033910/home/site/getjs?siteId=13751376
   baidu:
 
-  # Google 统计的 Tracking ID
-  # Google analytics, set Tracking ID
-  # See: https://developers.google.com/analytics/devguides/collection/analyticsjs
-  google:
-
-  # Google gtag.js 的媒体资源 ID
-  # Google gtag.js GA_MEASUREMENT_ID
-  # See: https://developers.google.com/analytics/devguides/collection/gtagjs/
-  gtag:
+  # Google Analytics 4 的媒体资源 ID
+  # Google Analytics 4 MEASUREMENT_ID
+  # See: https://support.google.com/analytics/answer/9744165#zippy=%2Cin-this-article
+  measurement:
 
   # 腾讯统计的 H5 App ID，开启高级功能才有cid
   # Tencent analytics, set APP ID

--- a/layout/_partials/plugins/analytics.ejs
+++ b/layout/_partials/plugins/analytics.ejs
@@ -15,29 +15,15 @@
     </script>
   <% } %>
 
-  <% if (theme.web_analytics.google){ %>
-    <!-- Google Analytics -->
+  <% if (theme.web_analytics.MeasurementID){ %>
+    <!-- Google tag (gtag.js) -->
     <script async>
       if (!Fluid.ctx.dnt) {
-        Fluid.utils.createScript('https://www.google-analytics.com/analytics.js', function() {
-          window.ga = window.ga || function() { (ga.q = ga.q || []).push(arguments) };
-          ga.l = +new Date;
-          ga('create', '<%= theme.web_analytics.google %>', 'auto');
-          ga('send', 'pageview');
-        });
-      }
-    </script>
-  <% } %>
-
-  <% if (theme.web_analytics.gtag){ %>
-    <!-- Google gtag.js -->
-    <script async>
-      if (!Fluid.ctx.dnt) {
-        Fluid.utils.createScript('https://www.googletagmanager.com/gtag/js?id=<%= theme.web_analytics.gtag %>', function() {
+        Fluid.utils.createScript("https://www.googletagmanager.com/gtag/js?id=<%= theme.web_analytics.measurement %>", function() {
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
-          gtag('config', '<%- theme.web_analytics.gtag %>');
+          gtag('config', '<%- theme.web_analytics.measurement %>');
         });
       }
     </script>


### PR DESCRIPTION
Universal Analytics (UA) will stop processing data on July 1, 2023 (July 1, 2024 for Analytics 360 properties). 
Google has officially merged the tracking ID and gtag ID. This RP integrates the two parts of tracking ID and gtag ID into MEASUREMENT ID
