### PR TITLE
修复`search.content`无法使用的BUG #912

### DIFF
--- a/scripts/generators/local-search.js
+++ b/scripts/generators/local-search.js
@@ -35,7 +35,7 @@ hexo.extend.generator.register('_hexo_generator_search', function(locals) {
 
   const searchConfig = config.search;
   let searchField = searchConfig.field;
-  const content = searchConfig.content || true;
+  const content = searchConfig.content && true;
 
   let posts, pages;
 

--- a/scripts/helpers/export-config.js
+++ b/scripts/helpers/export-config.js
@@ -8,23 +8,24 @@ const urlJoin = require('../utils/url-join');
 /**
  * Export theme config to js
  */
-hexo.extend.helper.register('export_config', function() {
+hexo.extend.helper.register('export_config', function () {
   let { config, theme, fluid_version } = this;
   const exportConfig = {
-    hostname     : url.parse(config.url).hostname || config.url,
-    root         : config.root,
-    version      : fluid_version,
-    typing       : theme.fun_features.typing,
-    anchorjs     : theme.fun_features.anchorjs,
-    progressbar  : theme.fun_features.progressbar,
+    hostname: url.parse(config.url).hostname || config.url,
+    root: config.root,
+    version: fluid_version,
+    typing: theme.fun_features.typing,
+    anchorjs: theme.fun_features.anchorjs,
+    progressbar: theme.fun_features.progressbar,
     code_language: theme.code.language,
-    copy_btn     : theme.code.copy_btn,
+    copy_btn: theme.code.copy_btn,
     image_caption: theme.post.image_caption,
-    image_zoom   : theme.post.image_zoom,
-    toc          : theme.post.toc,
-    lazyload     : theme.lazyload,
+    image_zoom: theme.post.image_zoom,
+    toc: theme.post.toc,
+    lazyload: theme.lazyload,
     web_analytics: theme.web_analytics,
-    search_path  : urlJoin(config.root, theme.search.path)
+    search_path: urlJoin(config.root, theme.search.path),
+    include_content_in_search: theme.search.content,
   };
   return `<script id="fluid-configs">
     var Fluid = window.Fluid || {};

--- a/source/js/local-search.js
+++ b/source/js/local-search.js
@@ -62,9 +62,11 @@
             var index_title = -1;
             var index_content = -1;
             var first_occur = -1;
-            // only match articles with not empty contents
-            if (data_content !== '') {
-              keywords.forEach(function(keyword, i) {
+            // Skip matching when content is included in search and content is empty
+            if (CONFIG.include_content_in_search && data_content === '') {
+              isMatch = false;
+            } else {
+              keywords.forEach(function (keyword, i) {
                 index_title = data_title.indexOf(keyword);
                 index_content = data_content.indexOf(keyword);
 
@@ -77,11 +79,8 @@
                   if (i === 0) {
                     first_occur = index_content;
                   }
-                  //content_index.push({index_content:index_content, keyword_len:keyword_len});
                 }
               });
-            } else {
-              isMatch = false;
             }
             // 0x05. show search results
             if (isMatch) {


### PR DESCRIPTION
### BUG 原因
1. 像 #912 里描述的一样，`searchConfig.content || true` 导致`content`设置永远为`true`
2. [local-search.js](https://github.com/fluid-dev/hexo-theme-fluid/compare/master...wuhao21:hexo-theme-fluid:master#diff-873e111eabba35a687c63ed2717d8ab4ce96cf1c3a1f9ec09e2bfdd001b2b6e8) 优化了搜索：如果内容为空就跳过。但是假如`searchConfig.content` 为 `false`，那么内容就永远为空

### 解决方法
1. 改为 `searchConfig.content && true`，对应注释里的“默认为True”
2.  Export `searchConfig.content`到后端，然后确保只有在`include_content_in_search`开启的时候才做这个优化。
### 测试 ( `searchConfig.content=false`)
- Before
![1](https://user-images.githubusercontent.com/12581701/220549774-34695468-eca0-4590-bae2-fd5025fd0fae.png)
- After
![2](https://user-images.githubusercontent.com/12581701/220549776-9dad0a20-9d88-45ad-83da-ec3bf6688719.png)

另外自动format了一下 scripts/helpers/export-config.js 如果要用之前的style请随意修改:)