### PR TITLE
脚注 增加支持中文、字母、数字混搭

### DIFF
--- a/scripts/tags/note.js
+++ b/scripts/tags/note.js
@@ -3,8 +3,8 @@
 'use strict';
 
 const note = (args, content) => {
-  if (!args || !args[0]) {
-    args = ['default'];
+  if (!args || !args[0] || args[0].toLowerCase() === "default") {
+    args = [ hexo.theme.config.post.updated.note_class || "info"];
   }
   return `<div class="note note-${args.join(' ')}">
             ${hexo.render.renderSync({ text: content, engine: 'markdown' }).split('\n').join('')}


### PR DESCRIPTION
增加脚注对中文和字母的支持。

```markdown

脚注[^可中文可汉字可数字]
[^可中文可汉字可数字]: 脚注 增加支持中文、字母、数字混搭

```