### PR TITLE
修正giscus主题设置问题

### DIFF
--- a/source/js/color-schema.js
+++ b/source/js/color-schema.js
@@ -11,6 +11,7 @@
   var defaultColorSchemaAttributeName = 'data-default-color-scheme';
   var colorToggleButtonSelector = '#color-toggle-btn';
   var colorToggleIconSelector = '#color-toggle-icon';
+  var iframeSelector = 'iframe';
 
   function setLS(k, v) {
     try {
@@ -247,6 +248,7 @@
           theme: giscusTheme,
         }
       };
+      giscus.style.cssText += 'color-scheme: normal;';
       giscus.contentWindow.postMessage({ 'giscus': message }, 'https://giscus.app');
     }
   }
@@ -276,4 +278,9 @@
       }
     }
   });
+
+  Fluid.utils.waitElementLoaded(iframeSelector, function() {
+    applyCustomColorSchemaSettings();
+  });
+  
 })(window, document);


### PR DESCRIPTION
这个问题分两个方面：
首先，评论区的iframe加载比较慢，导致这行代码：
[`var giscus = document.querySelector('iframe.giscus-frame');`](https://github.com/fluid-dev/hexo-theme-fluid/blob/9eefc8f24b42fbc9c430144bb059a655ae91d5e3/source/js/color-schema.js#L242)
`giscus` 始终返回 `null`，后续代码没有运行

其次，即便能正常运行，如果设置了黑色主题，评论区iframe会显示白色背景，这是个[已知BUG](https://github.com/giscus/giscus/issues/675)，看着很割裂：
![QQ截图20230721183142](https://github.com/fluid-dev/hexo-theme-fluid/assets/6732524/e8353585-f544-4eed-8c69-52f91395afb3)
合并PR的代码之后恢复正常：
![QQ截图20230721183208](https://github.com/fluid-dev/hexo-theme-fluid/assets/6732524/a1801fa2-9b42-4311-9f8e-5049720785d5)

