### PR TITLE
:bug: 修复 Google Analytics 4 (gtag)

### DIFF
--- a/layout/_partials/plugins/analytics.ejs
+++ b/layout/_partials/plugins/analytics.ejs
@@ -19,13 +19,13 @@
     <!-- Google tag (gtag.js) -->
     <script async>
       if (!Fluid.ctx.dnt) {
-        Fluid.utils.createScript("https://www.googletagmanager.com/gtag/js?id=<%= theme.web_analytics.google.measurement_id %>", function() {
+        Fluid.utils.createScript("https://www.googletagmanager.com/gtag/js?id=<%= theme.web_analytics.gtag %>", function() {
           window.dataLayer = window.dataLayer || [];
           function gtag() {
             dataLayer.push(arguments);
           }
           gtag('js', new Date());
-          gtag('config', '<%- theme.web_analytics.google.measurement_id %>');
+          gtag('config', '<%- theme.web_analytics.gtag %>');
         });
       }
     </script>


### PR DESCRIPTION
Google Analytics 4 (g-tag) 主题字段读取错误，导致无法正确获取统计结果。 