### PR TITLE
feat:增加折叠块功能 resolve #992

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -221,6 +221,19 @@ color:
   button_hover_bg_color: "#f2f3f5"
   button_hover_bg_color_dark: "#46647e"
 
+  # 折叠块标题文字的颜色
+  # Color of the text for the folding block title
+  fold_title_color: "#3c4858"
+  fold_title_color_dark: "#c4c6c9"
+  # 折叠块背景色
+  # Background color of the folding block
+  fold_bg_color: "#e5efe7"
+  fold_bg_color_dark: "#4f665b"
+  # 折叠块边框的颜色
+  # Color of the folding block border.
+  fold_board_color: "#e5efe7b8"
+  fold_board_color_dark: "#4f665bb8"
+
 # 主题字体配置
 # Font
 font:

--- a/scripts/tags/fold.js
+++ b/scripts/tags/fold.js
@@ -1,0 +1,32 @@
+hexo.extend.tag.register('fold', (args, content) => 
+    `<div class='fold collapsed'>
+        <div class='fold-title'>
+            ${args.join(" ")}
+        </div>
+        <div class='fold-content'>
+            ${
+                hexo.render.renderSync({
+                    text: content,
+                    engine: "markdown"
+                }) || "No content to show"
+            }
+        </div>
+    </div>`, {
+        ends: true
+});
+
+const folderScript = `(function (document) {
+    [].forEach.call(document.getElementsByClassName('fold'), function(panel) {
+        panel.getElementsByClassName('fold-title')[0].onclick = function() {
+            panel.classList.toggle("collapsed");
+            panel.classList.toggle("expanded");
+        }
+    });
+})(document);`;
+
+
+hexo.extend.filter.register('after_post_render', (data) => {
+    let link_js = `<script type="text/javascript">${folderScript}</script>`;
+    data.content += link_js;
+    return data;
+});

--- a/source/css/_pages/_base/color-schema.styl
+++ b/source/css/_pages/_base/color-schema.styl
@@ -19,6 +19,9 @@
   --button-hover-bg-color $button-hover-bg-color
   --highlight-bg-color $highlight-bg-color
   --inlinecode-bg-color $inlinecode-bg-color
+  --fold-title-color $fold-title-color
+  --fold-bg-color $fold-bg-color
+  --fold-board-color $fold-board-color
 
 dark-colors()
   --body-bg-color $body-bg-color-dark
@@ -40,6 +43,9 @@ dark-colors()
   --button-hover-bg-color $button-hover-bg-color-dark
   --highlight-bg-color $highlight-bg-color-dark
   --inlinecode-bg-color $inlinecode-bg-color-dark
+  --fold-title-color $fold-title-color-dark
+  --fold-bg-color $fold-bg-color-dark
+  --fold-board-color $fold-board-color-dark
 
   img
     -webkit-filter brightness(.9)

--- a/source/css/_pages/_post/post-tag.styl
+++ b/source/css/_pages/_post/post-tag.styl
@@ -1,3 +1,66 @@
+// fold
+.fold {
+    margin: 5px 0;
+    padding: 0 15px;
+    border: 0.5px solid var(--fold-board-color);
+    position: relative;
+    clear: both;
+    border-radius: 4px;
+}
+
+.fold .fold-title {
+    background: var(--fold-bg-color);
+    color: var(--fold-title-color);
+    margin: 0 -15px;
+    padding: 5px 15px;
+    font-weight: bold;
+    font-size: 14px;
+    display: block;
+    cursor: pointer;
+    border-radius: 3px;
+}
+
+.fold .fold-title:before {
+    font-weight: bold;
+}
+
+.fold.collapsed .fold-title:before {
+    content: "▶ ";
+}
+
+.fold.expanded .fold-title:before {
+    content: "▼ ";
+}
+
+.fold .fold-content {
+    padding-top: 0;
+    padding-bottom: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+    -moz-transition-duration: 0.8s;
+    -webkit-transition-duration: 0.8s;
+    -o-transition-duration: 0.8s;
+    transition-duration: 0.8s;
+    -moz-transition-timing-function: ease-in-out;
+    -webkit-transition-timing-function: ease-in-out;
+    -o-transition-timing-function: ease-in-out;
+    transition-timing-function: ease-in-out;
+}
+
+.fold.collapsed .fold-content {
+    overflow: hidden;
+    max-height: 0;
+}
+
+.fold.expanded .fold-content {
+    max-height: 3000px;
+    overflow: auto;
+}
+
+.fold .fold-content p:first-child {
+    margin-top: 0 !important;
+}
+
 // note
 .note
   padding 0.75rem

--- a/source/css/_variables/base.styl
+++ b/source/css/_variables/base.styl
@@ -31,6 +31,12 @@ $button-bg-color = theme-config("color.button_bg_color", "#f6f8fa")
 $button-bg-color-dark = theme-config("color.button_bg_color_dark", "#2f4154")
 $button-hover-bg-color = theme-config("color.button_hover_bg_color", "#f2f3f5")
 $button-hover-bg-color-dark = theme-config("color.button_hover_bg_color_dark", "#46647e")
+$fold-title-color = theme-config("color.fold_title_color", "#3c4858")
+$fold-title-color-dark = theme-config("color.fold_title_color_dark", "#c4c6c9")
+$fold-bg-color = theme-config("color.fold_bg_color", "#e5efe7")
+$fold-bg-color-dark = theme-config("color.fold_bg_color_dark", "#4f665b")
+$fold-board-color = theme-config("color.fold_board_color", "#e5efe7b8")
+$fold-board-color-dark = theme-config("color.fold_board_color_dark", "#4f665bb8")
 
 // navbar
 $navbar-bg-color = theme-config("color.navbar_bg_color", "#2f4154")


### PR DESCRIPTION
这是 #992 的 PR。

### feature
有些很长的参考内容，需要在文章中折叠起来，以便让读者有更好的阅读体验。

- [x] 支持文本、图片、代码块等各类元素的折叠
- [x] 支持用户自定义颜色
- [x] 支持白天/黑暗模式切换
- [x] 支持超长内容自动滚动。

### Demo
视频：https://github.com/AimTao/hexo-theme-fluid/blob/example/example.mp4

### usage
在行文过程中，增加标签。
```markdown
{% fold "折叠块的标题"%}
折叠内容，例如图片、代码块、文本等各类元素。
{% endfold %}
```
