### PR TITLE
:bug: 修复首页空白摘要在移动端仍然占位

### DIFF
--- a/source/css/_pages/_index/index.styl
+++ b/source/css/_pages/_index/index.styl
@@ -73,3 +73,7 @@
 
     .index-pin
       font-size 1.25rem
+
+  .index-excerpt
+    height auto
+    max-height calc(1.4rem * 3)


### PR DESCRIPTION
fix https://github.com/fluid-dev/hexo-theme-fluid/issues/991