### PR TITLE
Update analytics.ejs

### DIFF
--- a/layout/_partials/plugins/analytics.ejs
+++ b/layout/_partials/plugins/analytics.ejs
@@ -15,7 +15,7 @@
     </script>
   <% } %>
 
-  <% if (theme.web_analytics.google){ %>
+  <% if (theme.web_analytics.google && theme.web_analytics.google.measurement_id){ %>
     <!-- Google tag (gtag.js) -->
     <script async>
       if (!Fluid.ctx.dnt) {


### PR DESCRIPTION
修复 BUG：
开启 web_analytics 的情况下，即使 Google Analytics 为空，也会生成相应的 <script>

原 .ejs 文件
![image](https://github.com/fluid-dev/hexo-theme-fluid/assets/81098819/627e691b-2631-49b4-9dfd-ee992b2d0f46)

浏览器展示元素
![image](https://github.com/fluid-dev/hexo-theme-fluid/assets/81098819/853798b9-888c-4235-ba1e-6d92d3836d6f)

修复对比
![image](https://github.com/fluid-dev/hexo-theme-fluid/assets/81098819/9ec6482e-3ac4-4643-a9c8-7e988a967ef2)

![image](https://github.com/fluid-dev/hexo-theme-fluid/assets/81098819/f88f674e-d8e0-46bc-8b4c-fe6045469e29)
