### PR TITLE
Update _config.yml with anchor.js version 5.0.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -109,8 +109,16 @@ fun_features:
     element: h1,h2,h3,h4,h5,h6
     # Options: left | right
     placement: left
-    # Options: hover | always | touch
+
+    # `touch` 在 anchorjs 5.0.0 版本后被移除。visibility 设置的 `touch` 选项被移除，现在只有 `hover` 和 `always` 两个可选项
+    # 使用 `touch` 的站点会回退到 `hover` 的行为
+    # `touch` was removed after version 5.0.0 of anchorjs.
+    # The `touch` option on the visibility setting has been removed. Now the only visibility settings are `hover` and `always`. 
+    # Sites currently using `touch` (or any other unsupported visibility option) will fall back to the behavior for `hover`.
+
+    # Options: hover | always
     visible: hover
+
     # Options: § | # | ❡
     icon: ""
 
@@ -1057,7 +1065,7 @@ static_prefix:
   internal_css: /css
   internal_img: /img
 
-  anchor: https://lib.baomitu.com/anchor-js/4.3.1/
+  anchor: https://lib.baomitu.com/anchor-js/5.0.0/
 
   github_markdown: https://lib.baomitu.com/github-markdown-css/4.0.0/
 

--- a/_config.yml
+++ b/_config.yml
@@ -110,12 +110,6 @@ fun_features:
     # Options: left | right
     placement: left
 
-    # `touch` 在 anchorjs 5.0.0 版本后被移除。visibility 设置的 `touch` 选项被移除，现在只有 `hover` 和 `always` 两个可选项
-    # 使用 `touch` 的站点会回退到 `hover` 的行为
-    # `touch` was removed after version 5.0.0 of anchorjs.
-    # The `touch` option on the visibility setting has been removed. Now the only visibility settings are `hover` and `always`. 
-    # Sites currently using `touch` (or any other unsupported visibility option) will fall back to the behavior for `hover`.
-
     # Options: hover | always
     visible: hover
 


### PR DESCRIPTION
Breaking changes https://github.com/bryanbraun/anchorjs/releases/tag/5.0.0

修改原因：https://github.com/bryanbraun/anchorjs/issues/188#issuecomment-1382674984

`touch` 在 anchorjs 5.0.0 版本后被移除。visibility 设置的 `touch` 选项被移除，现在只有 `hover` 和 `always` 两个可选项
使用 `touch` 的站点会回退到 `hover` 的行为