### PR TITLE
增加功能：如果subtitle是数组，就随机选择一项。

### DIFF
--- a/layout/_partials/header/banner.ejs
+++ b/layout/_partials/header/banner.ejs
@@ -3,6 +3,10 @@ var banner_img = page.banner_img || theme.index.banner_img
 var banner_img_height = parseFloat(page.banner_img_height || theme.index.banner_img_height)
 var banner_mask_alpha = parseFloat(page.banner_mask_alpha || theme.index.banner_mask_alpha)
 var subtitle = page.subtitle || page.title
+// 如果subtitle是数组，就将其自己赋值为其自己的其中随机一个元素
+if (Array.isArray(subtitle)) {
+  subtitle = subtitle[Math.floor(Math.random() * subtitle.length)]
+}
 %>
 
 <div id="banner" class="banner" <%- theme.banner && theme.banner.parallax && 'parallax=true' %>


### PR DESCRIPTION
增加了如果subtitle是数组，就随机选择一项的功能。

```yaml
# 首页副标题的独立设置
# Independent config of home page subtitle
slogan:
  enable: true

  # 为空则按 hexo config.subtitle 显示
  # If empty, text based on `subtitle` in hexo config
  text: 
    - "伊万德在这个乱乱的小窝里睡觉。"
    - "伊万德喜欢软软的被子。"
    - "伊万德觉得下雨天在家里很舒服。"
    - "伊万德经常沉迷在浅浅的虚假的怀旧感中。"
    - "伊万德祝你快乐。"
```

我的博客的示例：https://zhider.github.io/blog/