### PR TITLE
替换 Waline 加载源为 CDNJS 并升级到 2.15.8

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1124,7 +1124,7 @@ static_prefix:
 
   valine: https://lib.baomitu.com/valine/1.5.1/
 
-  waline: https://cdn.staticfile.org/waline/2.15.5/
+  waline: https://cdnjs.cloudflare.com/ajax/libs/waline/2.15.8/
 
   gitalk: https://lib.baomitu.com/gitalk/1.8.0/
 


### PR DESCRIPTION
见 https://github.com/fluid-dev/hexo-theme-fluid/issues/1109