### PR TITLE
修复英文文章字数统计问题

### DIFF
--- a/scripts/helpers/wordcount.js
+++ b/scripts/helpers/wordcount.js
@@ -5,16 +5,17 @@
 const { stripHTML } = require('hexo-util');
 
 const getWordCount = (post) => {
-  // post.origin is the original post content of hexo-blog-encrypt
-  const content = stripHTML(post.origin || post.content).replace(/\r?\n|\r/g, '').replace(/\s+/g, '');
-
+  const content = stripHTML(post.origin || post.content).replace(/\r?\n|\r/g, ' ').trim();
+  
   if (!post.wordcount) {
+    // Match words and characters more accurately
     const zhCount = (content.match(/[\u4E00-\u9FA5]/g) || []).length;
-    const enCount = (content.replace(/[\u4E00-\u9FA5]/g, '').match(/[a-zA-Z0-9_\u0392-\u03c9\u0400-\u04FF]+|[\u4E00-\u9FFF\u3400-\u4dbf\uf900-\ufaff\u3040-\u309f\uac00-\ud7af\u0400-\u04FF]+|[\u00E4\u00C4\u00E5\u00C5\u00F6\u00D6]+|\w+/g) || []).length;
-    post.wordcount = zhCount + enCount
+    const enCount = (content.match(/[a-zA-Z0-9]+/g) || []).length;
+    post.wordcount = zhCount + enCount;
   }
   return post.wordcount;
 };
+
 
 const symbolsCount = (count) => {
   if (count > 9999) {


### PR DESCRIPTION
**问题描述**：在最新版本（1.9.8）中，英文文章的字数统计仍然不准确。例如，我的一篇全英文博客的字数应该是大约 2.8k 字，但实际显示只有 760 字。

### 示例

**修复前**：
![修复前](https://github.com/user-attachments/assets/8d2ad540-bbcd-4f0f-aef7-6b743f0e4873)

**代码**：
```javascript
const getWordCount = (post) => {
  const content = stripHTML(post.origin || post.content).replace(/\r?\n|\r/g, ' ').trim();
  
  if (!post.wordcount) {
    // 更准确地匹配单词和字符
    const zhCount = (content.match(/[\u4E00-\u9FA5]/g) || []).length;
    const enCount = (content.match(/[a-zA-Z0-9]+/g) || []).length;
    post.wordcount = zhCount + enCount;
  }
  return post.wordcount;
};
```

**修复后**：
![修复后](https://github.com/user-attachments/assets/4a59a3ad-29a1-4740-b1d6-868e5652dc13)

### 描述

更新后的 `getWordCount` 函数提高了对中文和英文文本字数统计的准确性。此更改解决了 1.9.8 版本中存在的统计不足的问题。