### PR TITLE
fix(umami): 修正请求头并优化参数配置说明

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -302,12 +302,12 @@ web_analytics:
     # statistics on the start time, the format is "YYYY-MM-DD"
     start_time: 2024-01-01
 
-    # 新建一个 umami viewOnly 用户，然后通过 login api 获取该用户 token
-    # create an umami viewOnly user, and then get user token through the login api
+    # 新建一个 umami viewOnly 用户，且有权限获取访问数据（通过团队），然后通过 login api 获取该用户 token
+    # create an umami viewOnly user with permission to access data (through the team), and then get user token through the login api
     token:
 
-    # 填写 umami 部署的服务器地址，如 "https://umami.example.com"
-    # server url of umami deployment, such as "https://umami.example.com"
+    # 填写 umami 的 api 链接前缀，如 "https://umami.example.com/api"
+    # server url of umami API link prefix, such as "https://umami.example.com/api"
     api_server:
 
 # Canonical 用于向 Google 搜索指定规范网址，开启前确保 hexo _config.yml 中配置 `url: http://yourdomain.com`

--- a/source/js/umami-view.js
+++ b/source/js/umami-view.js
@@ -26,12 +26,12 @@ const params = new URLSearchParams({
   startAt: start_time,
   endAt: end_time,
 });
-// 构造请求头
+// 构造请求头，参见https://umami.is/docs/api/authentication
 const request_header = {
   method: "GET",
   headers: {
-    "Content-Type": "application/json",
-    "x-umami-api-key": "oZKCH3msvqt10VlXKwoJvHclmaS4bVx0",
+    "Accept": "application/json",
+    "Authorization": `Bearer ${token}`,
   },
 };
 


### PR DESCRIPTION
- 单纯新建一个`umami viewOnly`用户是不行的，必须加入团队才有权限获取数据
- `api_server`应该是api的链接前缀，不一定是umami部署的服务器地址
- 请求头构造似乎有问题，修改后可正常获取数据