### PR TITLE
fix disqusjs url,identifier

### DIFF
--- a/layout/_partials/comments/disqus.ejs
+++ b/layout/_partials/comments/disqus.ejs
@@ -10,6 +10,8 @@
               shortname: '<%= theme.disqus.shortname %>',
               apikey: <%- JSON.stringify(theme.disqus.apikey) %>,
               api: '<%= theme.disqus.api %>',
+              url: '<%= page.permalink %>',
+              identifier: '<%= url_for(page.path) %>',
               admin: '<%= theme.disqus.admin %>',
               adminLabel: '<%= theme.disqus.adminLabel %>'
             });


### PR DESCRIPTION
If disqusjs is disabled:

https://github.com/fluid-dev/hexo-theme-fluid/blob/0f49caf39dc05eff9e2ea4d77d3b7f73ec1d9423/layout/_partials/comments/disqus.ejs#L18-L20

but if disqusjs is enabled, url and identifier is not specified(develop branch):

https://github.com/fluid-dev/hexo-theme-fluid/blob/b6865956e047c878cc5c80cef7774e9d1c14b824/layout/_partials/comments/disqus.ejs#L9-L15

As result, when I visit `example.com/a-post` has comments, but `example.com/a-post?v=t` has no comment.

**For disqusjs, url and identifier should keep same.**