### PR TITLE
css功能

### DIFF
--- a/layout/_partials/css.ejs
+++ b/layout/_partials/css.ejs
@@ -2,7 +2,7 @@
 
 <% var css_snippets = deduplicate(page.css_snippets) %>
 <% for (var idx = 0; idx < css_snippets.length; idx++) { %>
-  <%- css_snippets[idx] %>
+<%- css_snippets[idx] %>
 <% } %>
 <% page.css_snippets = [] %>
 
@@ -15,12 +15,26 @@
 <%- css_ex(theme.static_prefix.internal_css, 'main.css') %>
 
 <% if (theme.code.highlight.enable) { %>
-  <%- css_ex(theme.static_prefix.internal_css, 'highlight.css', 'id="highlight-css"') %>
-  <% if (theme.dark_mode.enable) { %>
-    <%- css_ex(theme.static_prefix.internal_css, 'highlight-dark.css', 'id="highlight-css-dark"') %>
-  <% } %>
+<%- css_ex(theme.static_prefix.internal_css, 'highlight.css', 'id="highlight-css"') %>
+<% if (theme.dark_mode.enable) { %>
+<%- css_ex(theme.static_prefix.internal_css, 'highlight-dark.css', 'id="highlight-css-dark"') %>
+<% } %>
 <% } %>
 
 <% if (theme.custom_css) { %>
-  <%- css(theme.custom_css) %>
+<%- css(theme.custom_css) %>
+<% } %>
+
+<% 
+function toCamelCase(str) {
+    return str
+        .replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, (match, index) => 
+            index === 0 ? match.toLowerCase() : match.toUpperCase()
+        )
+        .replace(/\s+/g, ''); // 去掉空格
+} 
+%>
+
+<% if (page.css) { %>
+<%- css_ex(theme.static_prefix.internal_css, `${toCamelCase(page.css)}.css` ) %>
 <% } %>


### PR DESCRIPTION
添加两行代码
使生成的html可以通过配置引入独立的css文件

使用方法：
在md头部添加css字段
```
---
title: Hello World
css: hello
---
```

css文件放在`/source/css/`文件夹下
css命名需要是小驼峰命名

以免md头部出现
```
css:hello World
```
这样的情况，创建了一个驼峰转换函数

---
后续看看能不能创建md同时创建符合要求的css文件