### PR TITLE
chore: 更新 mermaid 默认版本至 11.10.1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1110,7 +1110,7 @@ static_prefix:
 
   clipboard: https://lib.baomitu.com/clipboard.js/2.0.11/
 
-  mermaid: https://lib.baomitu.com/mermaid/8.14.0/
+  mermaid: https://lib.baomitu.com/mermaid/11.10.1/
 
   valine: https://lib.baomitu.com/valine/1.5.1/
 


### PR DESCRIPTION
8.14.0 版本太老了，很多稍微新一点的语法就无法支持了

see also: #977 