### PR TITLE
在首页添加h1标记

### DIFF
--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -7,6 +7,7 @@ page.banner_img_height = theme.index.banner_img_height
 page.banner_mask_alpha = theme.index.banner_mask_alpha
 %>
 
+<h1 style="display: none"><%= config.title %></h1>
 <% page.posts.each(function (post) { %>
   <div class="row mx-auto index-card">
     <% var post_url = url_for(post.path), index_img = post.index_img || theme.post.default_index_img %>


### PR DESCRIPTION

<img width="1540" height="695" alt="image" src="https://github.com/user-attachments/assets/99eb1ae4-884f-4374-ab18-e75a0af896c4" />
bing webmaster提示，该主题没有在首页添加h1标记，对seo性能有影响，所以在首页加上不可见的h1标记