### PR TITLE
使discus评论滚动条消失

### DIFF
--- a/layout/_partials/comments/cusdis.ejs
+++ b/layout/_partials/comments/cusdis.ejs
@@ -1,6 +1,7 @@
 <% if (theme.cusdis.host && theme.cusdis.app_id) { %>
-  <div class="cusdis" style="width:100%">
+  <div class="cusdis" style="width:100%; overflow:visible; min-height:480px;">
     <div id="cusdis_thread"
+      style="width:100%; overflow:visible;"
       data-host="<%= theme.cusdis.host %>"
       data-app-id="<%= theme.cusdis.app_id %>"
       data-page-id="<%= md5(page.path) %>"
@@ -15,6 +16,37 @@
       Fluid.utils.createScript('<%= url_join(theme.cusdis.host,
         `/js/widget/lang/${ String(theme.cusdis.lang || 'zh-cn').toLowerCase() }.js`) %>');
       Fluid.utils.createScript('<%= url_join(theme.cusdis.host, 'js/cusdis.es.js') %>');
+
+      // 取消容器滚动条，尝试让 iframe 展开显示
+      var container = document.querySelector('.cusdis');
+      var thread = document.querySelector('#cusdis_thread');
+      if (container) container.style.overflow = 'visible';
+      if (thread) thread.style.overflow = 'visible';
+
+      // 等待 widget 加载后调整 iframe 样式
+      setTimeout(function() {
+        try {
+          var iframe = thread && thread.querySelector('iframe');
+          if (iframe) {
+            iframe.style.width = '100%';
+            iframe.style.border = 'none';
+            iframe.style.overflow = 'visible';
+            iframe.style.minHeight = '600px';
+            iframe.setAttribute('scrolling', 'no');
+
+            // 若同源，尝试根据内容自适应高度
+            try {
+              var doc = iframe.contentDocument || iframe.contentWindow.document;
+              if (doc && doc.body) {
+                iframe.style.height = doc.body.scrollHeight + 'px';
+              }
+            } catch (e) {
+            }
+          }
+        } catch (e) {
+        }
+      }, 600);
+
       var schema = document.documentElement.getAttribute('data-user-color-scheme');
       if (schema) {
         document.querySelector('#cusdis_thread').dataset.theme = schema


### PR DESCRIPTION
discus默认是用容器装着的，右边有滚动条，而且每次只能看到很小一部分，h很丑

修改前
<img width="1619" height="890" alt="image" src="https://github.com/user-attachments/assets/dd3bcb90-0705-40e2-90bd-c185d55cdd4d" />
修改后
<img width="1604" height="890" alt="image" src="https://github.com/user-attachments/assets/75af7284-da83-4b27-93c5-19ab2eac1cae" />
