### PR TITLE
fix: 修复打字机随机标语在非首页也会显示的问题

### DIFF
--- a/layout/_partials/plugins/typed.ejs
+++ b/layout/_partials/plugins/typed.ejs
@@ -40,7 +40,7 @@
             typing(text);
           }
         })
-      <% } else if (Array.isArray(theme.index.slogan.text) && theme.index.slogan.text.length > 0) { %>
+      <% } else if (is_home() && Array.isArray(theme.index.slogan.text) && theme.index.slogan.text.length > 0) { %>
         var texts = <%- JSON.stringify(theme.index.slogan.text) %>;
         var idx = Math.floor(Math.random() * texts.length);
         typing(texts[idx]);


### PR DESCRIPTION
问题来自于：https://github.com/fluid-dev/hexo-theme-fluid/issues/1223
的后半段。

**Bug Description / 问题描述**
When `theme.index.slogan.text` is configured, the typing effect logic (Logic B) overrides the subtitle on all pages (including posts and archive pages), causing them to display the random slogan instead of the actual page title.

当配置了 `theme.index.slogan.text` 数组时，现有的判断逻辑会导致所有页面（包括文章页、归档页）都进入显示随机标语的逻辑，从而覆盖了原本应该显示的文章标题。

**Solution / 解决方案**
Add `is_home()` check to the condition.
在判断条件中增加 `is_home()` 检查，确保随机标语只在首页生效。