### PR TITLE
优化路径处理,避免非index.html的路径被加上/,导致umami查询参数错误

### DIFF
--- a/source/js/umami-view.js
+++ b/source/js/umami-view.js
@@ -94,6 +94,8 @@ let viewCtn = document.querySelector("#umami-page-views-container");
 // 如果页面容器存在，则获取页面浏览量
 if (viewCtn) {
   let path = window.location.pathname;
-  let target = decodeURI(path.replace(/\/*(index.html)?$/, "/"));
+  let target = path
+    .replace(/(\/[^/]+\.html)\/$/, "$1")  // 如果是 /xxx.html/ 则去掉最后那个 /
+    .replace(/\/index\.html$/, "/");  // 如果是 /index.html 则归一成 /
   pageStats(target);
 }


### PR DESCRIPTION
以下是控制台调试截图：

<img width="757" height="122" alt="umami-统计路径处理" src="https://github.com/user-attachments/assets/8afecaf3-9375-4875-af8e-de7fedc4c2eb" />

原来的正则逻辑在面对abc.html或者123.html这种格式的情况下，则会一股脑的在末尾加上 '/'，导致请求到umami的路径参数不正确，进而不能正确的获得当前网页的浏览量信息。

优化后的代码将逻辑分开进行处理，望开发者审阅