### PR TITLE
feat: Web analytics 新增 supabase

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -310,6 +310,16 @@ web_analytics:
     # server url of umami deployment, such as "https://umami.example.com"
     api_server:
 
+  supabase:
+    server_url:
+    anon_key:
+    # 统计页面时获取路径的属性
+    # Get the attribute of the page path during statistics
+    path: window.location.pathname
+    # 开启后不统计本地路径( localhost 与 127.0.0.1 )
+    # If true, ignore localhost & 127.0.0.1
+    ignore_local: true
+
 # Canonical 用于向 Google 搜索指定规范网址，开启前确保 hexo _config.yml 中配置 `url: http://yourdomain.com`
 # Canonical, to specify a canonical URL for Google Search, need to set up `url: http://yourdomain.com` in hexo _config.yml
 # See: https://support.google.com/webmasters/answer/139066
@@ -456,9 +466,9 @@ footer:
   statistics:
     enable: false
 
-    # 统计数据来源，使用 leancloud, umami 需要设置 `web_analytics` 中对应的参数；使用 busuanzi 不需要额外设置，但是有时不稳定，另外本地运行时 busuanzi 显示统计数据很大属于正常现象，部署后会正常
+    # 统计数据来源，使用 leancloud, umami, supabase 需要设置 `web_analytics` 中对应的参数；使用 busuanzi 不需要额外设置，但是有时不稳定，另外本地运行时 busuanzi 显示统计数据很大属于正常现象，部署后会正常
     # Data source. If use leancloud, umami, you need to set the parameter in `web_analytics`
-    # Options: busuanzi | leancloud | umami
+    # Options: busuanzi | leancloud | umami | supabase
     source: "busuanzi"
 
   # 国内大陆服务器的备案信息
@@ -601,7 +611,7 @@ post:
       enable: false
       # 统计数据来源
       # Data Source
-      # Options: busuanzi | leancloud | umami
+      # Options: busuanzi | leancloud | umami | supabase
       source: "busuanzi"
 
   # 在文章开头显示文章更新时间，该时间默认是 md 文件更新时间，可通过 front-matter 中 `updated` 手动指定（和 date 一样格式）

--- a/layout/_partials/footer/statistics.ejs
+++ b/layout/_partials/footer/statistics.ejs
@@ -52,6 +52,23 @@
       </span>
     <% } %>
     <% import_js(theme.static_prefix.internal_js, 'umami-view.js', 'defer') %>
+
+  <% } else if (theme.footer.statistics.source === 'supabase') { %>
+    <% if (pv_texts.length >= 2) { %>
+      <span id="supabase-site-pv-container" style="display: none">
+        <%- pv_texts[0] %>
+        <span id="supabase-site-pv"></span>
+        <%- pv_texts[1] %>
+      </span>
+    <% } %>
+    <% if (uv_texts.length >= 2) { %>
+      <span id="supabase-site-uv-container" style="display: none">
+        <%- uv_texts[0] %>
+        <span id="supabase-site-uv"></span>
+        <%- uv_texts[1] %>
+      </span>
+    <% } %>
+    <% import_js(theme.static_prefix.internal_js, 'supabase.js', 'defer') %>
   <% } %>
 
 </div>

--- a/layout/_partials/post/meta-top.ejs
+++ b/layout/_partials/post/meta-top.ejs
@@ -65,6 +65,13 @@
           <%- views_texts[0] %><span id="umami-page-views"></span><%- views_texts[1] %>
         </span>
         <% import_js(theme.static_prefix.internal_js, 'umami-view.js', 'defer') %>
+
+      <% } else if (theme.post.meta.views.source === 'supabase')  { %>
+        <span id="supabase-page-views-container" style="display: none">
+          <i class="iconfont icon-eye" aria-hidden="true"></i>
+          <%- views_texts[0] %><span id="supabase-page-views"></span><%- views_texts[1] %>
+        </span>
+        <% import_js(theme.static_prefix.internal_js, 'supabase.js', 'defer') %>
       <% } %>
     <% } %>
   </div>

--- a/source/js/supabase.js
+++ b/source/js/supabase.js
@@ -1,0 +1,114 @@
+/* global CONFIG */
+// eslint-disable-next-line no-console
+
+(function(window, document) {
+  var supabaseUrl = CONFIG.web_analytics.supabase.server_url;
+  var supabaseKey = CONFIG.web_analytics.supabase.anon_key;
+
+  if (!supabaseUrl) {
+    throw new Error('Supabase serverUrl is empty');
+  }
+  if (!supabaseKey) {
+    throw new Error('Supabase anonKey is empty');
+  }
+
+  // 参数: target (slug), amount (增加的数量，1 或 0)
+  // 这个 RPC 调用同时包含了更新和查询逻辑
+  function updateCounter(target, amount) {
+    return fetch(`${supabaseUrl}/rest/v1/rpc/update_counter`, {
+      method: 'POST',
+      headers: {
+        'apikey': supabaseKey,
+        'Authorization': `Bearer ${supabaseKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        slug_input: target,
+        increment_amount: amount
+      })
+    })
+    .then(res => res.json())
+    .then(data => data)
+    .catch(err => {
+      console.error('Supabase Error:', err);
+      return 0;
+    });
+  }
+
+  // 校验是否为有效的 Host
+  function validHost() {
+    if (window.location.protocol === 'file:') {
+      return false;
+    }
+    
+    if (CONFIG.web_analytics.supabase.ignore_local) {
+      var hostname = window.location.hostname;
+      if (hostname === 'localhost' || hostname === '127.0.0.1') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // 校验是否为有效的 UV
+  function validUV() {
+    var key = 'supabase_UV_Flag';
+    var flag = localStorage.getItem(key);
+    if (flag) {
+      // 距离标记小于 24 小时则不计为 UV
+      if (new Date().getTime() - parseInt(flag, 10) <= 86400000) {
+        return false;
+      }
+    }
+    localStorage.setItem(key, new Date().getTime().toString());
+    return true;
+  }
+
+  function addCount() {
+    var enableIncr = CONFIG.web_analytics.enable && !Fluid.ctx.dnt && validHost();
+    
+    // 请求 PV 并自增
+    var pvCtn = document.querySelector('#supabase-site-pv-container');
+    if (pvCtn) {
+      // 如果允许统计则 +1，否则 +0 (只读)
+      var amount = enableIncr ? 1 : 0;
+      updateCounter('site-pv', amount).then(count => {
+        var ele = document.querySelector('#supabase-site-pv');
+        if (ele) {
+          ele.innerText = count;
+          pvCtn.style.display = 'inline';
+        }
+      });
+    }
+
+    // 请求 UV 并自增
+    var uvCtn = document.querySelector('#supabase-site-uv-container');
+    if (uvCtn) {
+      var amount = (enableIncr && validUV()) ? 1 : 0;
+      updateCounter('site-uv', amount).then(count => {
+        var ele = document.querySelector('#supabase-site-uv');
+        if (ele) {
+          ele.innerText = count;
+          uvCtn.style.display = 'inline';
+        }
+      });
+    }
+
+    // 如果有页面浏览数节点，则请求浏览数并自增
+    var viewCtn = document.querySelector('#supabase-page-views-container');
+    if (viewCtn) {
+      var path = eval(CONFIG.web_analytics.supabase.path || 'window.location.pathname');
+      var target = decodeURI(path.replace(/\/*(index.html)?$/, '/'));
+      
+      var amount = enableIncr ? 1 : 0;
+      updateCounter(target, amount).then(count => {
+        var ele = document.querySelector('#supabase-page-views');
+        if (ele) {
+          ele.innerText = count;
+          viewCtn.style.display = 'inline';
+        }
+      });
+    }
+  }
+  addCount();
+})(window, document);


### PR DESCRIPTION
[Leancloud 即将停止服务](https://docs.leancloud.app/sdk/announcements/sunset-announcement)，所以添加了 Supabase 作为平替

如果这个 PR 能被合并，后续会在文档仓库提交配置 Supabase 的 PR

当前的 [workaround](https://blog.east.monster/2026/01/14/migrate-uv-pv-to-supabase/)

fix #1234