### PR TITLE
:bug: 优化umami参数路径处理

### DIFF
--- a/source/js/umami-view.js
+++ b/source/js/umami-view.js
@@ -94,6 +94,8 @@ let viewCtn = document.querySelector("#umami-page-views-container");
 // 如果页面容器存在，则获取页面浏览量
 if (viewCtn) {
   let path = window.location.pathname;
-  let target = decodeURI(path.replace(/\/*(index.html)?$/, "/"));
+  let target = path
+    .replace(/(\/[^/]+\.html)\/$/, "$1")  // 如果是 '/xxxx.html/' 格式的路径，则去掉最后那个 '/'
+    .replace(/\/index\.html$/, "/");      // 如果是 '/index.html' 格式，则合并成 '/'
   pageStats(target);
 }


### PR DESCRIPTION

<img width="757" height="122" alt="534969904-8afecaf3-9375-4875-af8e-de7fedc4c2eb" src="https://github.com/user-attachments/assets/725978f6-2400-4534-a8cf-5daaf9f9ae50" />


原来的正则逻辑在面对abc.html或者123.html这种格式的情况下，则会一股脑的在末尾加上 '/'，导致请求到umami的路径参数不正确，进而不能正确的获得当前网页的浏览量信息。

优化后的代码将逻辑分开进行处理，望开发者审阅

这次 PR 的提交信息按照历史提交记录的格式修改了