### PR TITLE
允许设置归档页是否启用分页

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -926,6 +926,7 @@ archive:
   banner_img: /img/default.png
   banner_img_height: 60
   banner_mask_alpha: 0.3
+  enable_paginator: true
 
 
 #---------------------------

--- a/layout/_partials/archive-list.ejs
+++ b/layout/_partials/archive-list.ejs
@@ -14,4 +14,6 @@
   <% }) %>
 </div>
 
+<% if(theme.archive.enable_paginator) { %>
 <%- partial('_partials/paginator') %>
+<% } %>


### PR DESCRIPTION
归档页面作为整理所有文章的页面，如果分页可能会导致用户体验大大下降（没法一下看到所有写的文章）。应该允许用户是否单独在这个页面设置是否分页
Add an enable_paginator flag to the archive section of _config.yml (default true) and wrap the paginator partial in layout/_partials/archive-list.ejs with a conditional check on theme.archive.enable_paginator. This allows enabling/disabling the archive paginator via configuration.