### PR TITLE
fix: escape footnote tooltip content in aria-label

### DIFF
--- a/scripts/events/lib/footnote.js
+++ b/scripts/events/lib/footnote.js
@@ -2,6 +2,15 @@
 
 const { stripHTML } = require('hexo-util');
 
+function escapeAttr(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 // Register footnotes filter
 module.exports = (hexo) => {
   const config = hexo.theme.config;
@@ -76,11 +85,11 @@ module.exports = (hexo) => {
         if (!indexMap[index]) {
           return match;
         }
-        const tooltip = indexMap[index].content;
+        const tooltip = escapeAttr(stripHTML(indexMap[index].content));
         return '<sup id="fnref:' + index + '" class="footnote-ref">'
           + '<a href="#fn:' + index + '" rel="footnote">'
           + '<span class="hint--top hint--rounded" aria-label="'
-          + stripHTML(tooltip)
+          + tooltip
           + '">[' + index + ']</span></a></sup>';
       });
 


### PR DESCRIPTION
﻿## Summary
- escape footnote tooltip text before inserting it into `aria-label`
- prevent footnote hover markup from breaking when the footnote content contains quotes

## Problem
The footnote tooltip renderer currently does `stripHTML()` and then injects the result directly into:

```html
<span class="hint--top hint--rounded" aria-label="...">
```

If the footnote content contains quotes, the generated `aria-label` can break and the hover span markup may be rendered as visible text instead of a tooltip.

## Reproduction
A footnote like this is enough to trigger it:

```md
[^4]: ... Jim Nightingale ("Jim the AI Whisperer") ...
[^5]: ... internal Agent "Goose" ...
```

## Fix
Apply HTML attribute escaping to the stripped footnote text before concatenating it into `aria-label`.

## Validation
- reproduced the issue in a local Hexo site using Fluid
- rebuilt the site after the patch
- verified that the generated footnote refs now render as valid tooltip markup
- verified that no leaked `<span class=...>` text appears in the page body
