### PR TITLE
修复暗色模式下搜索窗口关闭按钮样式

### DIFF
--- a/source/css/_pages/_base/_widget/search.styl
+++ b/source/css/_pages/_base/_widget/search.styl
@@ -7,3 +7,8 @@
 
   .search-word
     color orangered
+
+// Rewrite bootstrap
+button.close
+  text-shadow: none
+  transition opacity 0.2s ease, color 0.2s ease


### PR DESCRIPTION
对于搜索窗口的关闭按钮，bootstrap 样式中设定了阴影，在亮色模式下无问题，但在暗色模式下会出现重叠的效果。